### PR TITLE
feat: Implement visual validation feedback for AgentBuilderDialog tabs

### DIFF
--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -24,8 +24,10 @@ TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
-  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
->(({ className, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger> & {
+    statusIcon?: React.ReactNode;
+  }
+>(({ className, children, statusIcon, ...props }, ref) => (
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
@@ -33,7 +35,10 @@ const TabsTrigger = React.forwardRef<
       className,
     )}
     {...props}
-  />
+  >
+    {statusIcon && <span className="mr-2">{statusIcon}</span>}
+    {children}
+  </TabsPrimitive.Trigger>
 ));
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 


### PR DESCRIPTION
Implements visual indicators (icons) on TabsTrigger components within the AgentBuilderDialog to show the validation status of each tab.

Key changes:
- Modified `TabsTrigger` to accept a `statusIcon` prop for displaying validation status (error, complete).
- Updated `AgentBuilderDialog` to:
  - Determine tab status by checking `formState.errors` and `formState.dirtyFields` against a mapping of tabs to Zod schema fields.
  - Display an `AlertCircle` icon for tabs with validation errors and a `Check` icon for tabs that are considered complete (dirty and valid).
  - Disable the 'Salvar e Criar Agente' button if the form is invalid (`!formState.isValid`) or is currently submitting.
  - Added a loading spinner to the save button during submission.

This improves your experience by providing immediate feedback on which tabs require attention, helping to guide you in completing the agent configuration correctly.