### PR TITLE
feat(agent-builder): Enhance workflow agent configuration UI

### DIFF
--- a/src/components/features/agent-builder/WorkflowBehaviorForm.tsx
+++ b/src/components/features/agent-builder/WorkflowBehaviorForm.tsx
@@ -2,25 +2,96 @@
 // Inclui campos para tipo de workflow, descrição e máximo de iterações.
 
 import * as React from "react";
-import { useFormContext, Controller, useWatch } from "react-hook-form"; // MODIFIED
+import { useFormContext, Controller, useWatch, useFieldArray } from "react-hook-form"; // MODIFIED
 import { Input } from "@/components/ui/input";
 // import { Label } from "@/components/ui/label"; // Label from form will be used
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { SavedAgentConfiguration, WorkflowDetailedType } from "@/types/agent-configs"; // MODIFIED
+import { SavedAgentConfiguration, WorkflowDetailedType, TerminationConditionType } from "@/types/agent-configs"; // MODIFIED
 import { FormField, FormItem, FormLabel, FormControl, FormMessage, FormDescription } from "@/components/ui/form"; // MODIFIED
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"; // Added Card components
 import { Separator } from "@/components/ui/separator"; // Added Separator
+import { Button } from "@/components/ui/button"; // Added Button
 
 // MODIFIED: No props needed now
 interface WorkflowBehaviorFormProps {}
 
 const WorkflowBehaviorForm: React.FC<WorkflowBehaviorFormProps> = () => {
-  const { control, formState: { errors }, watch } = useFormContext<SavedAgentConfiguration>(); // MODIFIED
+  const { control, formState: { errors }, watch, setValue } = useFormContext<SavedAgentConfiguration>(); // MODIFIED
 
   const detailedWorkflowType = watch("config.detailedWorkflowType");
+  const loopTerminationConditionType = watch("config.loopTerminationConditionType");
+  const agentTools = watch("tools");
+  const agentToolsDetails = watch("toolsDetails");
+  const previousDetailedWorkflowType = React.useRef<WorkflowDetailedType | undefined>(detailedWorkflowType);
+
+  const { fields, append, remove, update, move } = useFieldArray({ // Added move
+    control,
+    name: "config.sequentialSteps",
+  });
+
+  React.useEffect(() => {
+    if (detailedWorkflowType === "sequential") {
+      const currentSequentialSteps = watch("config.sequentialSteps") || [];
+      const toolIdsInSteps = currentSequentialSteps.map(step => step.toolId);
+
+      // Add new tools from agentTools not in sequentialSteps
+      agentTools?.forEach(toolId => {
+        if (!toolIdsInSteps.includes(toolId)) {
+          append({ toolId: toolId, outputKey: "" });
+        }
+      });
+
+      // Remove tools from sequentialSteps not in agentTools
+      currentSequentialSteps.forEach((step, index) => {
+        if (!agentTools?.includes(step.toolId)) {
+          remove(index);
+        }
+      });
+
+      // Potentially re-order or update existing ones if agentTools order changes
+      // For now, this focuses on adding/removing. Reordering is complex with useFieldArray if not handled carefully.
+      // A more robust sync would involve creating a new array and replacing all fields if order is paramount.
+      // However, the prompt mentions "maintaining their current order from ToolsTab for now"
+      // and "useFieldArray will help manage adding/removing/updating these fields if the underlying tools list changes."
+      // This useEffect primarily handles sync when tools are added/removed from the agent globally.
+    }
+  }, [detailedWorkflowType, agentTools, agentToolsDetails, watch, append, remove]); // Removed setValue from deps as it's stable
+
+  React.useEffect(() => {
+    // Only run when detailedWorkflowType actually changes
+    if (previousDetailedWorkflowType.current !== detailedWorkflowType) {
+      // Reset fields for other workflow types
+      if (detailedWorkflowType !== "sequential") {
+        setValue("config.sequentialSteps", undefined);
+      } else {
+        // If switching TO sequential, re-trigger the sync logic for sequentialSteps
+        // This logic is already in the useEffect above, but we might need to ensure it runs
+        // by potentially clearing and letting the other effect repopulate.
+        // For now, the existing effect should handle it if agentTools are already populated.
+      }
+
+      if (detailedWorkflowType !== "parallel") {
+        setValue("config.parallelSubagentIds", undefined);
+      }
+
+      if (detailedWorkflowType !== "loop") {
+        setValue("config.loopMaxIterations", undefined);
+        setValue("config.loopTerminationConditionType", undefined);
+        setValue("config.loopExitToolName", undefined);
+        setValue("config.loopExitStateKey", undefined);
+        setValue("config.loopExitStateValue", undefined);
+      } else {
+        // If switching TO loop, set a default for loopTerminationConditionType if it's not already set
+        if (!watch("config.loopTerminationConditionType")) {
+          setValue("config.loopTerminationConditionType", "none");
+        }
+      }
+      previousDetailedWorkflowType.current = detailedWorkflowType;
+    }
+  }, [detailedWorkflowType, setValue, watch]);
 
   return (
     <div className="space-y-6">
@@ -77,13 +148,75 @@ const WorkflowBehaviorForm: React.FC<WorkflowBehaviorFormProps> = () => {
       {detailedWorkflowType === "sequential" && (
         <Card>
           <CardHeader>
-            <CardTitle>Sequential Workflow</CardTitle>
-            <CardDescription>Tools in a sequential workflow are executed in order. Reordering will be available here.</CardDescription>
+            <CardTitle>Sequential Workflow Configuration</CardTitle>
+            <CardDescription>
+              Define the order and output handling for tools in a sequential workflow.
+              Each tool will execute one after another. Use the "Move Up" and "Move Down" buttons to reorder the steps.
+              You can specify an "Output Key" for each tool if you need to reference its output in subsequent tools or steps (e.g., using {'{{stepName.outputKey}}'} in prompts).
+            </CardDescription>
           </CardHeader>
-          <CardContent>
-            <div className="p-4 border rounded-md bg-muted text-sm text-muted-foreground">
-              Drag-and-drop reordering of tools will be implemented here.
-            </div>
+          <CardContent className="space-y-4">
+            {fields.length === 0 && detailedWorkflowType === "sequential" && (
+              <Alert variant="info">
+                <AlertTitle>No Tools Added</AlertTitle>
+                <AlertDescription>
+                  This agent currently has no tools selected. Add tools in the "Tools" tab to configure them here for sequential execution.
+                </AlertDescription>
+              </Alert>
+            )}
+            {fields.map((item, index) => {
+              const toolDetail = agentToolsDetails?.find(td => td.id === item.toolId);
+              const toolName = toolDetail?.name || item.toolId;
+              return (
+                <div key={item.id} className="p-4 border rounded-md space-y-3">
+                  <div className="flex justify-between items-center">
+                    <h4 className="font-semibold">Step {index + 1}: {toolName}</h4>
+                    <div className="space-x-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => move(index, index - 1)}
+                        disabled={index === 0}
+                      >
+                        Move Up
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => move(index, index + 1)}
+                        disabled={index === fields.length - 1}
+                      >
+                        Move Down
+                      </Button>
+                      {/* Optional: Add a remove button if individual step removal is desired
+                      <Button variant="ghost" size="sm" onClick={() => remove(index)}>Remove Step</Button>
+                      */}
+                    </div>
+                  </div>
+                  <FormField
+                    control={control}
+                    name={`config.sequentialSteps.${index}.outputKey`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel htmlFor={`config.sequentialSteps.${index}.outputKey`}>Output Key (Optional)</FormLabel>
+                        <FormControl>
+                          <Input
+                            id={`config.sequentialSteps.${index}.outputKey`}
+                            placeholder="e.g., 'summaryOutput' or 'extractedData'"
+                            {...field}
+                            value={field.value || ""} // Ensure controlled component
+                          />
+                        </FormControl>
+                        <FormDescription>
+                          If you need this step's output later, give it a unique key. Example: <code>search_results</code>
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+              );
+            })}
           </CardContent>
         </Card>
       )}
@@ -97,61 +230,108 @@ const WorkflowBehaviorForm: React.FC<WorkflowBehaviorFormProps> = () => {
           <CardContent className="space-y-6">
             <FormField
               control={control}
-              name="config.loopExitToolName"
+              name="config.loopTerminationConditionType"
               render={({ field }) => (
                 <FormItem>
-                  <TooltipProvider> <Tooltip> <TooltipTrigger asChild><FormLabel htmlFor="config.loopExitToolName" className="cursor-help">Loop Exit Tool</FormLabel></TooltipTrigger> <TooltipContent><p>This tool, upon successful execution, will terminate the loop.</p></TooltipContent> </Tooltip> </TooltipProvider>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl><SelectTrigger id="config.loopExitToolName"><SelectValue placeholder="Select exit tool" /></SelectTrigger></FormControl>
-                    <SelectContent> {/* TODO: Populate with actual agent tools */} <SelectItem value="placeholder-tool">Placeholder Tool</SelectItem> </SelectContent>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild><FormLabel htmlFor="config.loopTerminationConditionType" className="cursor-help">Loop Termination Condition</FormLabel></TooltipTrigger>
+                      <TooltipContent className="w-80">
+                        <p>Determines how the loop will end:</p>
+                        <ul className="list-disc space-y-1 pl-4 mt-1">
+                          <li><strong>Max Iterations:</strong> Loop ends after a specific number of cycles.</li>
+                          <li><strong>Tool Success:</strong> Loop ends when a designated tool executes successfully.</li>
+                          <li><strong>State Change:</strong> Loop ends when a specific key in the agent's state matches a defined value.</li>
+                          <li><strong>None:</strong> Loop runs indefinitely or until manually stopped (use with caution).</li>
+                        </ul>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                  <Select onValueChange={field.onChange} value={field.value as TerminationConditionType}>
+                    <FormControl><SelectTrigger id="config.loopTerminationConditionType"><SelectValue placeholder="Select termination condition" /></SelectTrigger></FormControl>
+                    <SelectContent>
+                      <SelectItem value="max_iterations">Max Iterations</SelectItem>
+                      <SelectItem value="tool_success">Tool Success</SelectItem>
+                      <SelectItem value="state_change">State Change</SelectItem>
+                      <SelectItem value="none">None</SelectItem>
+                    </SelectContent>
                   </Select>
+                  <FormDescription>Specify the condition that will terminate the loop.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
             />
-            <FormField
-              control={control}
-              name="config.loopExitStateKey"
-              render={({ field }) => (
-                <FormItem>
-                  <TooltipProvider> <Tooltip> <TooltipTrigger asChild><FormLabel htmlFor="config.loopExitStateKey" className="cursor-help">Loop Exit State Key</FormLabel></TooltipTrigger> <TooltipContent><p>The key in the agent's state that will be checked for the loop exit value.</p></TooltipContent> </Tooltip> </TooltipProvider>
-                  <FormControl><Input id="config.loopExitStateKey" type="text" placeholder="Ex: agent_scratchpad.some_key" {...field} /></FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={control}
-              name="config.loopExitStateValue"
-              render={({ field }) => (
-                <FormItem>
-                  <TooltipProvider> <Tooltip> <TooltipTrigger asChild><FormLabel htmlFor="config.loopExitStateValue" className="cursor-help">Loop Exit State Value</FormLabel></TooltipTrigger> <TooltipContent><p>If the loop exit state key in the agent's state matches this value, the loop will terminate.</p></TooltipContent> </Tooltip> </TooltipProvider>
-                  <FormControl><Input id="config.loopExitStateValue" type="text" placeholder="Ex: loop_completed" {...field} /></FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-             <FormField
-              control={control}
-              name="config.loopMaxIterations"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel htmlFor="config.loopMaxIterations">Max Iterations</FormLabel>
-                  <FormControl>
-                    <Input
-                      id="config.loopMaxIterations"
-                      type="number"
-                      placeholder="Optional. Ex: 10"
-                      {...field}
-                      value={field.value === undefined ? "" : String(field.value)}
-                      onChange={e => field.onChange(e.target.value === "" ? undefined : Number(e.target.value))}
-                    />
-                  </FormControl>
-                  <FormDescription>Set a limit for loops within the workflow.</FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+
+            {loopTerminationConditionType === "max_iterations" && (
+              <FormField
+                control={control}
+                name="config.loopMaxIterations"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel htmlFor="config.loopMaxIterations">Maximum Loop Iterations</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="config.loopMaxIterations"
+                        type="number"
+                        placeholder="Enter maximum iterations (e.g., 10)"
+                        {...field}
+                        value={field.value === undefined ? "" : String(field.value)}
+                        onChange={e => field.onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+                      />
+                    </FormControl>
+                    <FormDescription>Set the maximum number of times the loop will execute.</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {loopTerminationConditionType === "tool_success" && (
+              <FormField
+                control={control}
+                name="config.loopExitToolName"
+                render={({ field }) => (
+                  <FormItem>
+                    <TooltipProvider> <Tooltip> <TooltipTrigger asChild><FormLabel htmlFor="config.loopExitToolName" className="cursor-help">Loop Exit Tool</FormLabel></TooltipTrigger> <TooltipContent><p>This tool, upon its successful execution, will terminate the loop. Select from the available tools for this agent.</p></TooltipContent> </Tooltip> </TooltipProvider>
+                    <Select onValueChange={field.onChange} value={field.value}>
+                      <FormControl><SelectTrigger id="config.loopExitToolName"><SelectValue placeholder="Select the tool that signals loop termination" /></SelectTrigger></FormControl>
+                      <SelectContent> {/* TODO: Populate with actual agent tools */} <SelectItem value="placeholder-tool">Placeholder: Tool Name (e.g., data_validator)</SelectItem> </SelectContent>
+                    </Select>
+                    <FormDescription>The loop will end if this tool executes successfully.</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {loopTerminationConditionType === "state_change" && (
+              <>
+                <FormField
+                  control={control}
+                  name="config.loopExitStateKey"
+                  render={({ field }) => (
+                    <FormItem>
+                      <TooltipProvider> <Tooltip> <TooltipTrigger asChild><FormLabel htmlFor="config.loopExitStateKey" className="cursor-help">Loop Exit State Key</FormLabel></TooltipTrigger> <TooltipContent><p>The specific key within the agent's state (e.g., from agent scratchpad or memory) that will be monitored. Example: <code>agent_data.status</code></p></TooltipContent> </Tooltip> </TooltipProvider>
+                      <FormControl><Input id="config.loopExitStateKey" type="text" placeholder="Enter state key to check (e.g., agent_scratchpad.job_status)" {...field} /></FormControl>
+                      <FormDescription>The key in the agent's state to check for the termination value.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={control}
+                  name="config.loopExitStateValue"
+                  render={({ field }) => (
+                    <FormItem>
+                      <TooltipProvider> <Tooltip> <TooltipTrigger asChild><FormLabel htmlFor="config.loopExitStateValue" className="cursor-help">Loop Exit State Value</FormLabel></TooltipTrigger> <TooltipContent><p>The loop will terminate if the value of the 'Loop Exit State Key' matches this value. Example: <code>COMPLETED</code></p></TooltipContent> </Tooltip> </TooltipProvider>
+                      <FormControl><Input id="config.loopExitStateValue" type="text" placeholder="Enter the value that signals termination (e.g., FINISHED)" {...field} /></FormControl>
+                      <FormDescription>The value the state key must have to terminate the loop.</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
           </CardContent>
         </Card>
       )}
@@ -160,14 +340,42 @@ const WorkflowBehaviorForm: React.FC<WorkflowBehaviorFormProps> = () => {
          <Card>
           <CardHeader>
             <CardTitle>Parallel Workflow</CardTitle>
+            <CardDescription>Configure subagents that will run in parallel. Ensure these subagents can operate independently.</CardDescription>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-6">
             <Alert variant="info">
-              <AlertTitle>Parallel Workflow Information</AlertTitle>
+              <AlertTitle>Important Considerations for Parallel Execution</AlertTitle>
               <AlertDescription>
-                Tasks in a parallel workflow should be independent to ensure correct execution. Configuration for parallel tasks will be available here.
+                Subagents in a parallel workflow must be independent and should not rely on shared state or sequential execution order from other parallel branches. Each subagent will operate in isolation.
               </AlertDescription>
             </Alert>
+            <FormField
+              control={control}
+              name="config.parallelSubagentIds"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel htmlFor="config.parallelSubagentIds">Subagents for Parallel Execution</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      id="config.parallelSubagentIds"
+                      placeholder="Enter comma-separated subagent IDs (e.g., agent_id_1, agent_id_2, agent_id_3)"
+                      {...field}
+                      value={Array.isArray(field.value) ? field.value.join(", ") : ""}
+                      onChange={e => {
+                        const value = e.target.value;
+                        field.onChange(value ? value.split(",").map(id => id.trim()) : []);
+                      }}
+                      rows={3}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Enter the IDs of subagents that will be executed in parallel.
+                    This will be improved with a multi-select component in the future.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
           </CardContent>
         </Card>
       )}

--- a/src/types/agent-configs.ts
+++ b/src/types/agent-configs.ts
@@ -158,6 +158,8 @@ export interface WorkflowAgentConfig extends AgentConfigBase {
   loopExitToolName?: string;
   loopExitStateKey?: string;
   loopExitStateValue?: string;
+  parallelSubagentIds?: string[];
+  sequentialSteps?: { toolId: string; outputKey?: string }[];
 }
 
 export interface CustomAgentConfig extends AgentConfigBase {


### PR DESCRIPTION
I've implemented several enhancements to the workflow agent configuration UI in the agent builder.

LoopAgent:
- I added an explicit dropdown for you to select the termination condition: "Max Iterations", "Tool Success", "State Change", or "None".
- I now conditionally display relevant input fields based on the chosen termination condition (e.g., max iterations input, tool selector, state key/value inputs).
- I clear loop-specific settings when you switch away from Loop type.

ParallelAgent:
- I added a field (currently a textarea for comma-separated IDs, intended for future upgrade to multi-select) for you to specify agents for parallel execution.
- I now display a persistent informational alert emphasizing the need for independent agents and no automatic history sharing.
- I clear parallel-specific settings when you switch away from Parallel type.

SequentialAgent:
- I now display tools added to the agent as steps in the sequence.
- I added an "Output Key" input field for each step, allowing you to name outputs for use in subsequent steps.
- I implemented "Move Up" and "Move Down" buttons for you to reorder steps in the sequence.
- I synchronized the list of sequential steps (and their output keys) with the main list of tools configured for the agent.
- I clear sequential-specific settings when you switch away from Sequential type.

General:
- I updated TypeScript type definitions in `agent-configs.ts` to support `parallelSubagentIds` and `sequentialSteps` (including `outputKey`).
- I refined form logic to reset workflow-specific fields when the workflow type is changed, improving data integrity.