### PR TITLE
feat: Enhance A2A config and add ADK Callback UI

### DIFF
--- a/src/components/features/agent-builder/a2a-config.tsx
+++ b/src/components/features/agent-builder/a2a-config.tsx
@@ -21,36 +21,51 @@ import {
 } from "@/components/ui/tooltip";
 import { SubAgentSelector } from "@/components/features/agent-builder/sub-agent-selector";
 import {
+import { useFormContext } from "react-hook-form"; // Added import
+import {
   A2AConfig as A2AConfigType,
   CommunicationChannel,
-} from "@/types/a2a-types";
+} from "@/types/agent-configs";
 import { SavedAgentConfiguration } from "@/types/agent-types";
 
 interface A2AConfigProps {
-  a2aConfig: A2AConfigType;
-  setA2AConfig: (config: A2AConfigType) => void;
   savedAgents?: SavedAgentConfiguration[];
+  // a2aConfig and setA2AConfig are removed as they come from useFormContext
 }
 
-export function A2AConfig({
-  a2aConfig,
-  setA2AConfig,
-  savedAgents = [],
-}: A2AConfigProps) {
+export function A2AConfig({ savedAgents = [] }: A2AConfigProps) {
+  const methods = useFormContext<SavedAgentConfiguration>();
+  const a2aConfig = methods.watch("config.a2a") || { // Watch the config.a2a path
+    enabled: false, // Provide a default structure if undefined
+    communicationChannels: [],
+    defaultResponseFormat: "json",
+    maxMessageSize: 1024 * 1024,
+    loggingEnabled: false,
+  };
+
+  const setA2AConfig = (newConfig: A2AConfigType | ((prev: A2AConfigType) => A2AConfigType)) => {
+    if (typeof newConfig === 'function') {
+      methods.setValue("config.a2a", newConfig(a2aConfig), { shouldValidate: true, shouldDirty: true });
+    } else {
+      methods.setValue("config.a2a", newConfig, { shouldValidate: true, shouldDirty: true });
+    }
+  };
+
   // Função para adicionar um novo canal
   const handleAddCommunicationChannel = () => {
+    const currentChannels = a2aConfig.communicationChannels || [];
     const newChannel: CommunicationChannel = {
       id: `channel-${Date.now()}`,
-      name: `Canal ${a2aConfig.communicationChannels.length + 1}`,
+      name: `Canal ${currentChannels.length + 1}`,
       direction: "bidirectional",
       messageFormat: "json",
       syncMode: "async",
     };
 
-    setA2AConfig({
-      ...a2aConfig,
-      communicationChannels: [...a2aConfig.communicationChannels, newChannel],
-    });
+    setA2AConfig((prev) => ({
+      ...prev,
+      communicationChannels: [...(prev.communicationChannels || []), newChannel],
+    }));
   };
 
   // Função para atualizar um canal existente
@@ -58,23 +73,36 @@ export function A2AConfig({
     index: number,
     updated: CommunicationChannel,
   ) => {
-    const newChannels = [...a2aConfig.communicationChannels];
+    const currentChannels = a2aConfig.communicationChannels || [];
+    const newChannels = [...currentChannels];
     newChannels[index] = updated;
-    setA2AConfig({
-      ...a2aConfig,
+    setA2AConfig((prev) => ({
+      ...prev,
       communicationChannels: newChannels,
-    });
+    }));
   };
 
   // Função para excluir um canal
   const handleDeleteChannel = (index: number) => {
-    const newChannels = [...a2aConfig.communicationChannels];
+    const currentChannels = a2aConfig.communicationChannels || [];
+    const newChannels = [...currentChannels];
     newChannels.splice(index, 1);
-    setA2AConfig({
-      ...a2aConfig,
+    setA2AConfig((prev) => ({
+      ...prev,
       communicationChannels: newChannels,
-    });
+    }));
   };
+
+  // Ensure a2aConfig and its nested properties are defined before rendering
+  if (!a2aConfig) {
+    // This can happen briefly if the form context is not yet updated
+    // Or if the default value for config.a2a is not set in the form
+    // You might want to render a loader or null here
+    return null;
+  }
+
+  const currentCommunicationChannels = a2aConfig.communicationChannels || [];
+
 
   return (
     <div className="space-y-6">
@@ -113,14 +141,14 @@ export function A2AConfig({
 
         <Card className="border-border/50">
           <CardContent className="p-4 space-y-4">
-            {a2aConfig.communicationChannels.length === 0 ? (
+            {currentCommunicationChannels.length === 0 ? (
               <div className="text-center py-4 text-sm text-muted-foreground">
                 Nenhum canal definido. Adicione canais para permitir comunicação
                 com outros agentes.
               </div>
             ) : (
-              a2aConfig.communicationChannels.map((channel, index) => (
-                <div key={index} className="border rounded-md p-3 space-y-3">
+              currentCommunicationChannels.map((channel, index) => (
+                <div key={channel.id || index} className="border rounded-md p-3 space-y-3"> {/* Ensure key is stable */}
                   <div className="flex justify-between items-center">
                     <Input
                       value={channel.name}
@@ -156,7 +184,7 @@ export function A2AConfig({
                             </Label>
                           </TooltipTrigger>
                           <TooltipContent>
-                            <p>Inbound: Agent receives messages. Outbound: Agent sends messages. Bidirectional: Agent can send and receive messages.</p>
+                            <p>Define se o canal é para receber mensagens (Inbound), enviar mensagens (Outbound), ou ambos (Bidirectional). Relevante para o fluxo de comunicação A2A.</p>
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>
@@ -199,11 +227,11 @@ export function A2AConfig({
                               htmlFor={`channel-format-${channel.id}`}
                               className="text-xs"
                             >
-                              Formato
+                              Formato da Mensagem
                             </Label>
                           </TooltipTrigger>
                           <TooltipContent>
-                            <p>Defines the data structure for messages (JSON for structured data, Text for plain text, Binary for custom formats).</p>
+                            <p>Formato da mensagem trocada pelo canal. JSON para dados estruturados, Text para texto simples, Binary para formatos customizados. Crucial para a serialização/deserialização no protocolo A2A.</p>
                           </TooltipContent>
                         </Tooltip>
                       </TooltipProvider>
@@ -229,11 +257,175 @@ export function A2AConfig({
                         </SelectContent>
                       </Select>
                     </div>
+                    <div>
+                      <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <Label
+                              htmlFor={`channel-syncmode-${channel.id}`}
+                              className="text-xs"
+                            >
+                              Modo de Sincronização
+                            </Label>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Modo de sincronização do canal. 'Sync' para operações bloqueantes onde uma resposta é esperada. 'Async' para operações não bloqueantes. Afeta como o agente lida com o envio/recebimento.</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <Select
+                        value={channel.syncMode}
+                        onValueChange={(value) =>
+                          handleUpdateChannel(index, {
+                            ...channel,
+                            syncMode: value as "sync" | "async",
+                            // Reset retryPolicy if switching away from sync
+                            retryPolicy: value === 'async' ? undefined : channel.retryPolicy,
+                          })
+                        }
+                      >
+                        <SelectTrigger
+                          id={`channel-syncmode-${channel.id}`}
+                          className="h-8"
+                        >
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="sync">Síncrono (Sync)</SelectItem>
+                          <SelectItem value="async">Assíncrono (Async)</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
                   </div>
+
+                  {channel.syncMode === "sync" && (
+                    <div className="grid grid-cols-2 gap-3 mt-3 border-t pt-3">
+                      <div>
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger>
+                              <Label
+                                htmlFor={`channel-retries-${channel.id}`}
+                                className="text-xs"
+                              >
+                                Max Retries
+                              </Label>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Configura a política de novas tentativas para canais síncronos. Define o número máximo de tentativas. Importante para a robustez da comunicação A2A.</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <Input
+                          id={`channel-retries-${channel.id}`}
+                          type="number"
+                          placeholder="Ex: 3"
+                          value={channel.retryPolicy?.maxRetries ?? ""}
+                          onChange={(e) => {
+                            const maxRetries = parseInt(e.target.value);
+                            handleUpdateChannel(index, {
+                              ...channel,
+                              retryPolicy: {
+                                ...(channel.retryPolicy || { delayMs: 1000 }), // Default delayMs if creating policy
+                                maxRetries: isNaN(maxRetries) ? 0 : maxRetries,
+                              },
+                            });
+                          }}
+                          className="h-8"
+                        />
+                      </div>
+                      <div>
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger>
+                              <Label
+                                htmlFor={`channel-interval-${channel.id}`}
+                                className="text-xs"
+                              >
+                                Retry Interval (ms)
+                              </Label>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Configura a política de novas tentativas para canais síncronos. Define o intervalo entre elas em milissegundos. Importante para a robustez da comunicação A2A.</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <Input
+                          id={`channel-interval-${channel.id}`}
+                          type="number"
+                          placeholder="Ex: 1000"
+                          value={channel.retryPolicy?.delayMs ?? ""}
+                          onChange={(e) => {
+                            const delayMs = parseInt(e.target.value);
+                            handleUpdateChannel(index, {
+                              ...channel,
+                              retryPolicy: {
+                                ...(channel.retryPolicy || { maxRetries: 3 }), // Default maxRetries if creating policy
+                                delayMs: isNaN(delayMs) ? 0 : delayMs,
+                              },
+                            });
+                          }}
+                          className="h-8"
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  {channel.messageFormat === "json" && (
+                    <div className="mt-3 border-t pt-3">
+                      <div className="flex justify-between items-center mb-1">
+                        <TooltipProvider>
+                          <Tooltip>
+                            <TooltipTrigger>
+                              <Label
+                                htmlFor={`channel-schema-${channel.id}`}
+                                className="text-xs"
+                              >
+                                Schema JSON
+                              </Label>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Define o esquema JSON para validação de mensagens quando o formato é JSON. Ajuda a garantir a integridade dos dados na comunicação A2A.</p>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                        <Button
+                          variant="link"
+                          size="sm"
+                          className="h-auto p-0 text-xs"
+                          onClick={() => window.open('https://jsonlint.com/', '_blank')}
+                        >
+                          Validar JSON
+                        </Button>
+                      </div>
+                      <Input // Using Input, but could be Textarea for larger schemas
+                        id={`channel-schema-${channel.id}`}
+                        placeholder='{"type": "object", "properties": {...}}'
+                        value={channel.schema || ""}
+                        onChange={(e) =>
+                          handleUpdateChannel(index, {
+                            ...channel,
+                            schema: e.target.value,
+                          })
+                        }
+                        className="h-8 text-xs" // Might want a Textarea for better UX with schemas
+                      />
+                    </div>
+                  )}
+
                   {(channel.direction === "outbound" ||
                     channel.direction === "bidirectional") && (
-                    <div className="mt-3">
-                      <Label className="text-xs">Agente Alvo</Label>
+                    <div className="mt-3 border-t pt-3">
+                       <TooltipProvider>
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <Label className="text-xs">Agente Alvo</Label>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Seleciona o agente de destino para canais de saída ou bidirecionais. Fundamental para o roteamento de mensagens no A2A.</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
                       <SubAgentSelector
                         selectedAgents={
                           channel.targetAgentId ? [channel.targetAgentId] : []
@@ -282,12 +474,12 @@ export function A2AConfig({
               </Tooltip>
             </TooltipProvider>
             <Select
-              value={a2aConfig.defaultResponseFormat}
+              value={a2aConfig.defaultResponseFormat || "json"} // Provide default if undefined
               onValueChange={(value) =>
-                setA2AConfig({
-                  ...a2aConfig,
+                setA2AConfig((prev) => ({
+                  ...prev,
                   defaultResponseFormat: value as "json" | "text",
-                })
+                }))
               }
             >
               <SelectTrigger id="defaultResponseFormat" className="h-8">
@@ -316,15 +508,14 @@ export function A2AConfig({
             <Input
               id="maxMessageSize"
               type="number"
-              value={a2aConfig.maxMessageSize || ""}
-              onChange={(e) =>
-                setA2AConfig({
-                  ...a2aConfig,
-                  maxMessageSize: e.target.value
-                    ? parseInt(e.target.value)
-                    : undefined,
-                })
-              }
+              value={a2aConfig.maxMessageSize ?? ""} // Use nullish coalescing for potentially undefined value
+              onChange={(e) => {
+                const val = e.target.value;
+                setA2AConfig((prev) => ({
+                  ...prev,
+                  maxMessageSize: val ? parseInt(val) : 0, // Ensure it's a number, or a defined default like 0
+                }));
+              }}
               className="h-8"
             />
           </div>
@@ -333,9 +524,9 @@ export function A2AConfig({
         <div className="flex items-center space-x-2">
           <Switch
             id="loggingEnabled"
-            checked={a2aConfig.loggingEnabled}
+            checked={!!a2aConfig.loggingEnabled} // Ensure boolean value
             onCheckedChange={(checked) =>
-              setA2AConfig({ ...a2aConfig, loggingEnabled: checked })
+              setA2AConfig((prev) => ({ ...prev, loggingEnabled: checked }))
             }
           />
           <TooltipProvider>

--- a/src/lib/zod-schemas.ts
+++ b/src/lib/zod-schemas.ts
@@ -144,7 +144,25 @@ export const agentConfigBaseSchema = z.object({
   rag: ragMemoryConfigSchema.optional(),
   artifacts: artifactsConfigSchema.optional(),
   a2a: a2aConfigSchema.optional(),
+  // adkCallbacks will be added here
 });
+
+// Schema for ADKCallbacksConfig
+export const adkCallbacksConfigSchema = z.object({
+  beforeAgent: z.string().optional().describe("Genkit flow name or function reference to call before the agent starts processing."),
+  afterAgent: z.string().optional().describe("Genkit flow name or function reference to call after the agent finishes processing."),
+  beforeModel: z.string().optional().describe("Genkit flow name or function reference to call before a model is invoked."),
+  afterModel: z.string().optional().describe("Genkit flow name or function reference to call after a model is invoked."),
+  beforeTool: z.string().optional().describe("Genkit flow name or function reference to call before a tool is used."),
+  afterTool: z.string().optional().describe("Genkit flow name or function reference to call after a tool is used.")
+}).optional();
+
+
+// Update agentConfigBaseSchema to include adkCallbacks
+export const updatedAgentConfigBaseSchema = agentConfigBaseSchema.extend({
+  adkCallbacks: adkCallbacksConfigSchema, // Already optional from its own definition
+});
+
 
 // Schema for LLMAgentConfig
 export const llmAgentConfigSchema = agentConfigBaseSchema.extend({
@@ -186,11 +204,18 @@ export const a2aAgentSpecialistConfigSchema = agentConfigBaseSchema.extend({
 });
 
 // Discriminated union for AgentConfig
+// IMPORTANT: Re-define specific agent configs to use the updated base schema
+export const llmAgentConfigSchemaUpdated = updatedAgentConfigBaseSchema.extend(llmAgentConfigSchema.shape);
+export const workflowAgentConfigSchemaUpdated = updatedAgentConfigBaseSchema.extend(workflowAgentConfigSchema.shape);
+export const customAgentConfigSchemaUpdated = updatedAgentConfigBaseSchema.extend(customAgentConfigSchema.shape);
+export const a2aAgentSpecialistConfigSchemaUpdated = updatedAgentConfigBaseSchema.extend(a2aAgentSpecialistConfigSchema.shape);
+
+
 export const agentConfigSchema = z.discriminatedUnion("type", [
-  llmAgentConfigSchema,
-  workflowAgentConfigSchema,
-  customAgentConfigSchema,
-  a2aAgentSpecialistConfigSchema,
+  llmAgentConfigSchemaUpdated,
+  workflowAgentConfigSchemaUpdated,
+  customAgentConfigSchemaUpdated,
+  a2aAgentSpecialistConfigSchemaUpdated,
 ]);
 
 // Schema for SavedAgentConfiguration

--- a/src/types/agent-configs.ts
+++ b/src/types/agent-configs.ts
@@ -39,24 +39,48 @@ export interface ToolConfigData {
 
 export interface CommunicationChannel {
   id: string;
-  type: "direct_http" | "message_queue" | "custom";
-  targetAgentId?: string;
-  protocol?: "http" | "https";
-  endpoint?: string;
-  topic?: string;
-  brokerUrl?: string;
-  customConfig?: Record<string, any>;
-  description?: string;
+  name: string;
+  direction: 'inbound' | 'outbound';
+  targetAgentId?: string; // Optional, as per original, but consider if it should be mandatory for outbound
+  messageFormat: 'json' | 'text' | 'binary';
+  schema?: string; // Optional, can be a JSON schema string or URL
+  syncMode: 'sync' | 'async';
+  timeout?: number; // Optional, in milliseconds
+  retryPolicy?: {
+    maxRetries: number;
+    delayMs: number;
+    backoffFactor?: number; // Optional
+  };
 }
 
 export interface A2AConfig {
   enabled: boolean;
   communicationChannels: CommunicationChannel[];
-  defaultResponseFormat: "json" | "text" | "xml";
+  defaultResponseFormat: "json" | "text";
   maxMessageSize: number;
   loggingEnabled: boolean;
   securityPolicy?: "none" | "jwt" | "api_key";
   apiKeyHeaderName?: string;
+}
+
+/**
+ * Defines configuration for ADK (Agent Development Kit) callbacks.
+ * These callbacks allow for invoking Genkit flows or function references
+ * at various stages of an agent's lifecycle.
+ */
+export interface ADKCallbacksConfig {
+  /** Genkit flow name or function reference to call before the agent starts processing. */
+  beforeAgent?: string;
+  /** Genkit flow name or function reference to call after the agent finishes processing. */
+  afterAgent?: string;
+  /** Genkit flow name or function reference to call before a model is invoked. */
+  beforeModel?: string;
+  /** Genkit flow name or function reference to call after a model is invoked. */
+  afterModel?: string;
+  /** Genkit flow name or function reference to call before a tool is used. */
+  beforeTool?: string;
+  /** Genkit flow name or function reference to call after a tool is used. */
+  afterTool?: string;
 }
 
 export interface ArtifactDefinition {
@@ -139,6 +163,7 @@ export interface AgentConfigBase {
   genkitFlowName?: string;
   inputSchema?: string;
   outputSchema?: string;
+  adkCallbacks?: ADKCallbacksConfig;
 }
 
 export interface LLMAgentConfig extends AgentConfigBase {


### PR DESCRIPTION
I've implemented comprehensive UI and configuration enhancements for Agent-to-Agent (A2A) communication and introduced a new section for configuring ADK (Agent Development Kit) lifecycle callbacks within the Agent Builder.

A2A Communication Tab:
- I replaced the basic A2A textarea with a dedicated configuration component (`a2a-config.tsx`).
- I unified `CommunicationChannel` and `A2AConfig` types, now primarily managed in `agent-configs.ts`.
- `targetAgentId` now correctly uses the `SubAgentSelector` component for selecting from your saved agents.
- I added UI for `syncMode` in communication channels.
- I added UI for `retryPolicy` (maxRetries, retryInterval) for synchronous channels.
- I added an input field for `schema` for JSON message formats, with an external link button to a JSON validator.
- I added descriptive tooltips for A2A configuration fields to clarify concepts for you.

ADK Callbacks ("Avançado" Tab):
- I added a new "Avançado" tab to the Agent Builder dialog.
- I introduced `ADKCallbacksConfig` type to `agent-configs.ts` and added `adkCallbacks` to `AgentConfigBase`.
- I implemented UI within the "Avançado" tab for configuring ADK lifecycle callbacks:
    - `beforeAgent`
    - `afterAgent`
    - `beforeModel`
    - `afterModel`
    - `beforeTool`
    - `afterTool`
- Each callback input field is accompanied by a description of its purpose.
- I updated Zod schemas (`savedAgentConfigurationSchema`) to include validation for the new `adkCallbacks` structure.
- I updated `react-hook-form` default values to support the new A2A and ADK callback configurations.