### PR TITLE
feat: Implement agent configuration versioning and rollback

### DIFF
--- a/src/types/agent-configs.ts
+++ b/src/types/agent-configs.ts
@@ -250,4 +250,7 @@ export interface SavedAgentConfiguration {
     hasConfig?: boolean;
     genkitToolName?: string;
   }>;
+  internalVersion: number;
+  isLatest: boolean;
+  originalAgentId: string;
 }


### PR DESCRIPTION
This commit introduces a versioning system for agent configurations.

Key changes:
- Modified `SavedAgentConfiguration` type to include `internalVersion` (numeric), `isLatest` (boolean), and `originalAgentId` (string) to track and manage versions.
- The `createAgent` action now initializes these versioning fields for new agents, with `internalVersion: 1`, `isLatest: true`, and `originalAgentId` set to the agent's own ID.
- The `updateAgent` action has been significantly reworked. Instead of modifying an agent document in place, it now:
    1. Sets `isLatest: false` on the current latest version.
    2. Creates a new agent document (a new version) with an incremented `internalVersion`, `isLatest: true`, and the updated configuration. The `originalAgentId` is carried over.
- Added a new `getAgentHistory` action that takes an `originalAgentId` and `userId` to retrieve all versions of an agent, sorted by `internalVersion` in descending order.
- Added a new `restoreAgentVersion` action that allows you to select a specific historical version and make it the new latest version. This is achieved by creating a new version document based on the selected historical data.

Conceptual guidance for UI changes and unit tests has been provided. Further work will be needed to implement:
- UI components to display version history and allow restoration.
- Adjustments to agent listing and deletion logic to account for versions.
- Comprehensive unit tests for the new and modified actions.