### PR TITLE
feat: Implement agent template functionality

### DIFF
--- a/src/app/templates/page.tsx
+++ b/src/app/templates/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from "@/components/ui/card";
+import { SavedAgentConfiguration } from "@/types/agent-configs";
+import {
+  getUserAgentTemplates,
+  getCommunityAgentTemplates,
+} from "@/lib/agentServices";
+// import { useAuth } from "@/contexts/AuthContext"; // Optional for now
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  // const { user } = useAuth(); // Optional for now
+
+  const [userTemplates, setUserTemplates] = React.useState<SavedAgentConfiguration[]>([]);
+  const [communityTemplates, setCommunityTemplates] = React.useState<SavedAgentConfiguration[]>([]);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    const fetchTemplates = async () => {
+      setIsLoading(true);
+      // const currentUserId = user?.uid; // Use actual user ID when auth is integrated
+      const currentUserId = "test-user-id"; // Placeholder for now
+
+      try {
+        if (currentUserId) {
+          const uTemplates = await getUserAgentTemplates(currentUserId);
+          setUserTemplates(uTemplates);
+        }
+        const cTemplates = await getCommunityAgentTemplates();
+        setCommunityTemplates(cTemplates);
+      } catch (error) {
+        console.error("Failed to fetch templates:", error);
+        // Handle error (e.g., show toast)
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchTemplates();
+  }, [/* user */]); // Add user to dependency array if using actual user
+
+  const handleUseTemplate = (templateId: string) => {
+    router.push(`/agent-builder?templateId=${templateId}`);
+  };
+
+  if (isLoading) {
+    return <div className="p-4">Carregando templates...</div>;
+  }
+
+  return (
+    <div className="space-y-8 p-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-3xl font-bold">Templates de Agentes</h1>
+      </header>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Meus Templates</h2>
+        {userTemplates.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {userTemplates.map((template) => (
+              <Card key={template.id}>
+                <CardHeader>
+                  <CardTitle>{template.agentName}</CardTitle>
+                  <CardDescription>{template.agentDescription || "Sem descrição."}</CardDescription>
+                </CardHeader>
+                <CardContent>
+                  {/* Display other template info if needed */}
+                  <p className="text-sm text-muted-foreground">Versão: {template.agentVersion}</p>
+                </CardContent>
+                <CardFooter>
+                  <Button onClick={() => handleUseTemplate(template.id)}>Usar Template</Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <p>Você ainda não salvou nenhum template.</p>
+        )}
+      </section>
+
+      <section>
+        <h2 className="text-2xl font-semibold mb-4">Templates da Comunidade</h2>
+        {communityTemplates.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {communityTemplates.map((template) => (
+              // Avoid rendering user's own templates again if they appear in community list
+              // This logic can be refined if community templates are strictly not user's own.
+              (userTemplates.find(ut => ut.id === template.id)) ? null : (
+                <Card key={template.id}>
+                  <CardHeader>
+                    <CardTitle>{template.agentName}</CardTitle>
+                    <CardDescription>{template.agentDescription || "Sem descrição."}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">Versão: {template.agentVersion}</p>
+                    {/* Optionally display author/source for community templates */}
+                  </CardContent>
+                  <CardFooter>
+                    <Button onClick={() => handleUseTemplate(template.id)}>Usar Template</Button>
+                  </CardFooter>
+                </Card>
+              )
+            ))}
+          </div>
+        ) : (
+          <p>Nenhum template da comunidade disponível no momento.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/features/agent-builder/agent-card.tsx
+++ b/src/components/features/agent-builder/agent-card.tsx
@@ -148,6 +148,7 @@ interface AgentCardProps {
   onTest: (agent: SavedAgentConfiguration) => void;
   onDelete: (agentId: string) => void;
   onViewMonitoring: (agent: SavedAgentConfiguration) => void; // New prop for monitoring
+  onSaveAsTemplate: (agent: SavedAgentConfiguration) => void; // New prop
   availableTools: AvailableTool[]; // Necessário para obter o label correto e o ícone da ferramenta
   agentTypeOptions: {
     id: string;
@@ -163,6 +164,7 @@ export function AgentCard({
   onTest,
   onDelete,
   onViewMonitoring, // Destructure new prop
+  onSaveAsTemplate, // Destructure new prop
   availableTools,
   agentTypeOptions,
 }: AgentCardProps) {
@@ -442,6 +444,9 @@ export function AgentCard({
       <CardFooter className="gap-2 mt-auto pt-4 border-t">
         <Button variant="outline" size="sm" onClick={() => onEdit(agent)}>
           <EditIcon size={16} className="mr-1.5" /> Editar
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => onSaveAsTemplate(agent)}>
+          <SaveIcon size={16} className="mr-1.5" /> Salvar como Template
         </Button>
         <Button variant="outline" size="sm" onClick={() => onViewMonitoring(agent)}>
           <EyeIcon size={16} className="mr-1.5" /> Monitorar

--- a/src/types/agent-configs.ts
+++ b/src/types/agent-configs.ts
@@ -250,6 +250,7 @@ export interface SavedAgentConfiguration {
   agentVersion: string;
   icon?: string;
   templateId?: string;
+  isTemplate?: boolean; // New field
   isFavorite?: boolean;
   tags?: string[];
   createdAt: string;


### PR DESCRIPTION
This commit introduces the ability for you to save existing agents as templates and then use these templates to create new agents.

Key changes include:
- Added an `isTemplate` field to the `SavedAgentConfiguration` interface.
- Implemented new Firestore service functions in `agentServices.ts` to manage an `agent-templates` collection.
- Added a "Save as Template" button to the `AgentCard` component and corresponding handler logic in `AgentBuilderPage`.
- Created a new `/templates` page to list user-created templates and (in the future) community templates. Templates can be selected from this page to pre-fill the agent creation form in `AgentBuilderPage`.
- Functionality to load template data into the agent builder when navigating with a `templateId` query parameter.

This provides the foundational features for agent reuse and will facilitate future community sharing capabilities.