### PR TITLE
qFeature/multi user prep

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -29,13 +29,12 @@ service cloud.firestore {
       }
     }
 
-    // Agents Collection (for Phase 3):
-    // Users can read, create, update, and delete their own agents.
-    match /agents/{agentId} {
-      // For 'create': ensure the incoming resource has the userId set to the auth.uid.
-      // For 'read, update, delete': ensure the existing resource's userId matches auth.uid.
-      allow read, update, delete: if request.auth != null && resource.data.userId == request.auth.uid;
-      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+    // Agent Configurations Collection:
+    // Users can read, create, update, and delete their own agent configurations.
+    // Access is controlled by matching the 'ownerId' field with the authenticated user's UID.
+    match /agent-configurations/{agentId} {
+      allow read, update, delete: if request.auth != null && resource.data.ownerId == request.auth.uid;
+      allow create: if request.auth != null && request.resource.data.ownerId == request.auth.uid;
     }
 
     // Agent Templates Collection:

--- a/src/types/agent-configs.ts
+++ b/src/types/agent-configs.ts
@@ -196,6 +196,8 @@ export interface AgentConfigBase {
   inputSchema?: string;
   outputSchema?: string;
   adkCallbacks?: ADKCallbacksConfig;
+  ownerId?: string;
+  sharedWith?: { userId: string, role: 'viewer' | 'editor' }[];
 }
 
 export interface ModelSafetySettingItem {


### PR DESCRIPTION
- Add ownerId and sharedWith fields to agent data model.
- Update agentServices to manage ownerId on agent creation/update and initialize sharedWith.
- Update agentServices to query agents by ownerId.
- Update Firestore security rules for agent-configurations to use ownerId and enforce ownership.
- Verified UI logic for delegating user-specific operations to the API.

Note: Full multi-user functionality requires API routes to implement proper user authentication and authorization instead of placeholder IDs.