### PR TITLE
feat: Refactor ChatUI with useChatStore hook

### DIFF
--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -27,6 +27,7 @@ export interface ChatMessageUI {
   fileName?: string;
   fileDataUri?: string;
   isStreaming?: boolean; // Added for streaming
+  isError?: boolean; // Added/Ensured
   status?: 'pending' | 'completed' | 'error'; // Added status for UI
   toolUsed?: {
     name: string;


### PR DESCRIPTION
I refactored the chat functionality by introducing a new `useChatStore` hook (`src/hooks/use-chat-store.ts`).

This hook now centralizes all chat-related state management and core logic, including:
- Conversation state (conversations, activeConversationId)
- Message state (messages, optimistic updates for UI)
- Handlers for creating, selecting, renaming, and deleting conversations
- Message submission logic, including API calls for streaming agent responses and Firestore persistence for both user and agent messages
- Message feedback and regeneration capabilities
- File handling state related to message attachments

The `ChatUI.tsx` component has been significantly simplified, now primarily responsible for:
- Rendering the UI structure
- Passing user interactions and contextual data (like `activeChatTarget` and `testRunConfig`) to the `useChatStore` hook.
- Sourcing all chat state and core action dispatchers from the hook.

`ConversationSidebar.tsx` remains largely unchanged structurally but now receives its props from `ChatUI` which are sourced from `useChatStore`.

The `ChatMessageUI` type in `src/types/chat.ts` has been updated to include `isError` and ensure `isStreaming` fields.

This refactoring aims to:
- Reduce complexity in `ChatUI.tsx`.
- Improve separation of concerns by isolating chat state and logic.
- Enhance maintainability and testability of the chat feature.