### PR TITLE
feat: Optimize images and static assets

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -17,6 +17,7 @@ const nextConfig: NextConfig = {
         pathname: '/**',
       },
     ],
+    formats: ['image/avif', 'image/webp'],
   },
 };
 

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -4,6 +4,7 @@
 import type { ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { AppLogo } from "@/components/icons/logo";
 import {
   Cpu,
   MessageSquare,
@@ -171,7 +172,7 @@ export function AppLayout({ children }: { children: ReactNode }) {
               href="/agent-builder"
               className="hover:text-sidebar-primary/90 transition-colors"
             >
-              <span className="aida-logo-text">Aida</span>
+              <AppLogo className="h-8 w-8" />
             </Link>
           )}
         </SidebarHeader>


### PR DESCRIPTION
- I've configured Next.js image optimization to prefer AVIF and WebP formats in `next.config.ts`.
- I replaced the text-based logo in `app-layout.tsx` with the `AppLogo` component (using a lucide-react icon) for consistency and optimized rendering.
- I verified that `ChatMessageDisplay.tsx` uses `next/image` for content images and `lucide-react` for icons.
- I confirmed that `chat-ui.tsx` and `WelcomeScreen.tsx` primarily use `lucide-react` icons.
- The specific files `logo-assistente.svg` and `avatar-usuario.svg` were not found in the project, and their likely intended uses are covered by existing `lucide-react` icons (`Bot`, `User`).

These changes aim to improve loading performance and ensure consistent use of optimized assets, addressing the core requirements of the issue.