### PR TITLE
feat: Implement UX enhancements for Bloco 2

### DIFF
--- a/src/app/agent-builder/page.tsx
+++ b/src/app/agent-builder/page.tsx
@@ -19,6 +19,7 @@ import {
   Info,
   MessageSquareText,
   Edit3,
+  Ghost, // Added Ghost icon
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { saveAgentTemplate, getAgentTemplate } from "@/lib/agentServices";
@@ -52,6 +53,7 @@ import { HelpModal } from '@/components/ui/HelpModal';
 import { guidedTutorials, GuidedTutorial, TutorialStep } from '@/data/agent-builder-help-content';
 import { FeedbackButton } from "@/components/features/agent-builder/feedback-button";
 import { FeedbackModal } from "@/components/features/agent-builder/feedback-modal";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export default function AgentBuilderPage() {
   const { toast } = useToast();
@@ -312,7 +314,23 @@ export default function AgentBuilderPage() {
               <Plus className="mr-2 h-4 w-4" /> Novo Agente (Formulário)
             </Button>
           </div>
-          {isLoadingAgents && <p className="text-center py-4">Carregando agentes...</p>}
+          {isLoadingAgents && (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div key={index} className="p-4 rounded-lg border border-border bg-card space-y-4 h-[210px] flex flex-col justify-between">
+                  <div>
+                    <div className="flex items-center space-x-3 mb-3">
+                      <Skeleton className="h-10 w-10 rounded-md" />
+                      <Skeleton className="h-5 w-1/2" />
+                    </div>
+                    <Skeleton className="h-4 w-full mb-2" />
+                    <Skeleton className="h-4 w-3/4" />
+                  </div>
+                  <Skeleton className="h-9 w-full" />
+                </div>
+              ))}
+            </div>
+          )}
           {!isLoadingAgents && savedAgents.length > 0 ? (
             <div className="space-y-6">
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
@@ -335,13 +353,19 @@ export default function AgentBuilderPage() {
             </div>
           ) : (
             !isLoadingAgents && (
-              <div className="text-center py-12 border-2 border-dashed border-border rounded-lg bg-card">
-                <Layers className="mx-auto h-12 w-12 text-muted-foreground" />
-                <h3 className="mt-4 text-lg font-medium text-foreground">
-                  Nenhum agente criado ainda
-                </h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Use o botão "Novo Agente (Formulário)" acima ou alterne para "Conversar com IA" para criar seu primeiro agente.
+              <div className="text-center py-16 border-2 border-dashed border-border rounded-lg bg-card shadow-sm">
+                <Ghost className="mx-auto h-20 w-20 text-muted-foreground/70" />
+                <h2 className="mt-6 text-xl font-semibold text-foreground">
+                  Crie seu Primeiro Agente Inteligente
+                </h2>
+                <p className="mt-2 text-sm text-muted-foreground max-w-md mx-auto">
+                  Agentes são assistentes de IA personalizados que você pode construir para realizar tarefas específicas, automatizar processos ou interagir de formas únicas. Comece agora mesmo!
+                </p>
+                <Button onClick={handleOpenCreateAgentModal} className="mt-6">
+                  <Plus className="mr-2 h-4 w-4" /> Novo Agente (Formulário)
+                </Button>
+                <p className="mt-4 text-xs text-muted-foreground">
+                  Ou alterne para "Conversar com IA" para uma criação guiada.
                 </p>
               </div>
             )

--- a/src/app/agent-monitor/page.tsx
+++ b/src/app/agent-monitor/page.tsx
@@ -18,6 +18,10 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  Activity, BarChartBig, FileQuestion, Inbox, LineChart, ListX, PieChart, ScrollText, SearchX, ShieldAlert, Table2
+} from "lucide-react"; // Added icons
+import { Skeleton } from "@/components/ui/skeleton"; // Import Skeleton
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import {
@@ -132,6 +136,15 @@ function DatePicker({ date, setDate, placeholder }: { date?: Date, setDate: (dat
   );
 }
 
+// Helper component for consistent empty states
+const EmptyStateDisplay = ({ icon: Icon, title, message, suggestion }: { icon: React.ElementType, title: string, message: string, suggestion?: string }) => (
+  <div className="flex flex-col items-center justify-center text-center py-10 md:py-16">
+    <Icon className="w-12 h-12 text-muted-foreground/70 mb-4" />
+    <h3 className="text-lg font-semibold text-foreground mb-1">{title}</h3>
+    <p className="text-sm text-muted-foreground max-w-md">{message}</p>
+    {suggestion && <p className="text-xs text-muted-foreground/80 mt-2">{suggestion}</p>}
+  </div>
+);
 
 export default function AgentMonitorPage() {
   const [filters, setFilters] = useState<Filters>(initialFilters);
@@ -592,9 +605,20 @@ export default function AgentMonitorPage() {
       {/* Agent Status Summary */}
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Agent Status Overview</h2>
-        {agentStatusLoading && <p className="text-center py-4 text-muted-foreground">Loading agent status...</p>}
-        {agentStatusError && <p className="text-red-500 text-center py-4">{agentStatusError}</p>}
-        {!agentStatusLoading && !agentStatusError && agentStatusData.length > 0 && (
+        {agentStatusLoading ? (
+          <div className="grid grid-cols-2 gap-4 text-center">
+            <div>
+              <Skeleton className="h-8 w-1/4 mx-auto mb-2" />
+              <Skeleton className="h-4 w-1/2 mx-auto" />
+            </div>
+            <div>
+              <Skeleton className="h-8 w-1/4 mx-auto mb-2" />
+              <Skeleton className="h-4 w-1/2 mx-auto" />
+            </div>
+          </div>
+        ) : agentStatusError ? (
+          <p className="text-red-500 text-center py-4">{agentStatusError}</p>
+        ) : agentStatusData.length > 0 ? (
           <div className="grid grid-cols-2 gap-4 text-center">
             <div>
               <p className="text-3xl font-bold text-green-500">{agentStatusData.filter(a => a.isActive).length}</p>
@@ -607,16 +631,22 @@ export default function AgentMonitorPage() {
           </div>
         )}
          {!agentStatusLoading && !agentStatusError && agentStatusData.length === 0 && (
-          <p className="text-center py-4 text-muted-foreground">No agent status data available.</p>
+          <EmptyStateDisplay
+            icon={Activity}
+            title="Nenhum Status de Agente"
+            message="Não há dados de status de agente disponíveis no momento."
+          />
         )}
       </div>
 
       {/* Execution History Chart */}
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Execution History (Mock Data)</h2>
-        {executionHistoryLoading && <p className="text-center py-10 text-muted-foreground">Loading chart...</p>}
-        {executionHistoryError && <p className="text-red-500 text-center py-10">{executionHistoryError}</p>}
-        {!executionHistoryLoading && !executionHistoryError && executionHistoryData.length > 0 && (
+        {executionHistoryLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : executionHistoryError ? (
+          <p className="text-red-500 text-center py-10">{executionHistoryError}</p>
+        ) : executionHistoryData.length > 0 ? (
           <ChartContainer config={executionHistoryChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart
@@ -637,16 +667,22 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!executionHistoryLoading && !executionHistoryError && executionHistoryData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No execution history data available.</p>
+          <EmptyStateDisplay
+            icon={ListX}
+            title="Nenhum Histórico de Execução"
+            message="Não há dados de histórico de execução disponíveis."
+          />
         )}
       </div>
 
       {/* Average Response Time Chart (Mock) */}
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Average Response Times (Mock Data)</h2>
-        {averageResponseTimeLoading && <p className="text-center py-10 text-muted-foreground">Loading chart...</p>}
-        {averageResponseTimeError && <p className="text-red-500 text-center py-10">{averageResponseTimeError}</p>}
-        {!averageResponseTimeLoading && !averageResponseTimeError && averageResponseTimeData.length > 0 && (
+        {averageResponseTimeLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : averageResponseTimeError ? (
+          <p className="text-red-500 text-center py-10">{averageResponseTimeError}</p>
+        ) : averageResponseTimeData.length > 0 ? (
           <ChartContainer config={averageResponseTimeChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={averageResponseTimeData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -664,16 +700,22 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!averageResponseTimeLoading && !averageResponseTimeError && averageResponseTimeData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No average response time data available.</p>
+          <EmptyStateDisplay
+            icon={LineChart}
+            title="Nenhum Dado de Tempo de Resposta"
+            message="Não há dados de tempo médio de resposta disponíveis."
+          />
         )}
       </div>
 
       {/* Tool Usage Metrics Chart (Mock) */}
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Tool Usage Metrics (Mock Data)</h2>
-        {toolUsageMetricsLoading && <p className="text-center py-10 text-muted-foreground">Loading chart...</p>}
-        {toolUsageMetricsError && <p className="text-red-500 text-center py-10">{toolUsageMetricsError}</p>}
-        {!toolUsageMetricsLoading && !toolUsageMetricsError && toolUsageMetricsData.length > 0 && (
+        {toolUsageMetricsLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : toolUsageMetricsError ? (
+          <p className="text-red-500 text-center py-10">{toolUsageMetricsError}</p>
+        ) : toolUsageMetricsData.length > 0 ? (
           <ChartContainer config={toolUsageMetricsChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={toolUsageMetricsData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -688,16 +730,22 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!toolUsageMetricsLoading && !toolUsageMetricsError && toolUsageMetricsData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No tool usage metrics data available.</p>
+          <EmptyStateDisplay
+            icon={PieChart}
+            title="Nenhuma Métrica de Uso de Ferramenta"
+            message="Não há métricas de uso de ferramenta disponíveis."
+          />
         )}
       </div>
 
       {/* Existing charts below - these are driven by API and filters */}
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Agent Usage Frequency</h2>
-        {agentUsageLoading && <p className="text-center py-10">Loading chart...</p>}
-        {agentUsageError && <p className="text-red-500 text-center py-10">Error loading agent usage: {agentUsageError}</p>}
-        {!agentUsageLoading && !agentUsageError && agentUsageData.length > 0 && (
+        {agentUsageLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : agentUsageError ? (
+          <p className="text-red-500 text-center py-10">Error loading agent usage: {agentUsageError}</p>
+        ) : agentUsageData.length > 0 ? (
           <ChartContainer config={agentUsageChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={agentUsageData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -715,16 +763,23 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!agentUsageLoading && !agentUsageError && agentUsageData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No data available for the selected filters.</p>
+          <EmptyStateDisplay
+            icon={BarChartBig}
+            title="Nenhum Uso de Agente"
+            message="Nenhum dado de uso de agente disponível para os filtros selecionados."
+            suggestion="Tente ajustar os filtros ou aguarde novos dados."
+          />
         )}
       </div>
       
       {/* Keep other placeholders for now */}
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Flow Usage Frequency</h2>
-        {flowUsageLoading && <p className="text-center py-10">Loading chart...</p>}
-        {flowUsageError && <p className="text-red-500 text-center py-10">Error loading flow usage: {flowUsageError}</p>}
-        {!flowUsageLoading && !flowUsageError && flowUsageData.length > 0 && (
+        {flowUsageLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : flowUsageError ? (
+          <p className="text-red-500 text-center py-10">Error loading flow usage: {flowUsageError}</p>
+        ) : flowUsageData.length > 0 ? (
           <ChartContainer config={flowUsageChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={flowUsageData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -739,15 +794,22 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!flowUsageLoading && !flowUsageError && flowUsageData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No data available for the selected filters.</p>
+          <EmptyStateDisplay
+            icon={BarChartBig}
+            title="Nenhum Uso de Fluxo"
+            message="Nenhum dado de uso de fluxo disponível para os filtros selecionados."
+            suggestion="Tente ajustar os filtros ou aguarde novos dados."
+          />
         )}
       </div>
 
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Tool Usage Frequency</h2>
-        {toolUsageLoading && <p className="text-center py-10">Loading chart...</p>}
-        {toolUsageError && <p className="text-red-500 text-center py-10">Error loading tool usage: {toolUsageError}</p>}
-        {!toolUsageLoading && !toolUsageError && toolUsageData.length > 0 && (
+        {toolUsageLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : toolUsageError ? (
+          <p className="text-red-500 text-center py-10">Error loading tool usage: {toolUsageError}</p>
+        ) : toolUsageData.length > 0 ? (
           <ChartContainer config={toolUsageChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={toolUsageData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -762,15 +824,22 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!toolUsageLoading && !toolUsageError && toolUsageData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No data available for the selected filters.</p>
+          <EmptyStateDisplay
+            icon={BarChartBig}
+            title="Nenhum Uso de Ferramenta"
+            message="Nenhum dado de uso de ferramenta disponível para os filtros selecionados."
+            suggestion="Tente ajustar os filtros ou aguarde novos dados."
+          />
         )}
       </div>
       
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Error Rates (by Flow Name)</h2>
-        {errorRatesLoading && <p className="text-center py-10">Loading chart...</p>}
-        {errorRatesError && <p className="text-red-500 text-center py-10">Error loading error rates: {errorRatesError}</p>}
-        {!errorRatesLoading && !errorRatesError && errorRatesData.length > 0 && (
+        {errorRatesLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : errorRatesError ? (
+          <p className="text-red-500 text-center py-10">Error loading error rates: {errorRatesError}</p>
+        ) : errorRatesData.length > 0 ? (
           <ChartContainer config={errorRatesChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={errorRatesData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -785,15 +854,22 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!errorRatesLoading && !errorRatesError && errorRatesData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No data available for the selected filters.</p>
+          <EmptyStateDisplay
+            icon={ShieldAlert}
+            title="Nenhuma Taxa de Erro"
+            message="Nenhuma taxa de erro disponível para os filtros selecionados."
+            suggestion="Tente ajustar os filtros ou aguarde novos dados."
+          />
         )}
       </div>
 
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Average Response Times (by Flow Name)</h2>
-        {avgResponseTimesLoading && <p className="text-center py-10">Loading chart...</p>}
-        {avgResponseTimesError && <p className="text-red-500 text-center py-10">Error loading average response times: {avgResponseTimesError}</p>}
-        {!avgResponseTimesLoading && !avgResponseTimesError && avgResponseTimesData.length > 0 && (
+        {avgResponseTimesLoading ? (
+          <Skeleton className="h-[300px] w-full rounded-md" />
+        ) : avgResponseTimesError ? (
+          <p className="text-red-500 text-center py-10">Error loading average response times: {avgResponseTimesError}</p>
+        ) : avgResponseTimesData.length > 0 ? (
           <ChartContainer config={avgResponseTimesChartConfig} className="min-h-[200px] w-full">
             <ResponsiveContainer width="100%" height={300}>
               <BarChart data={avgResponseTimesData} margin={{ top: 5, right: 20, left: 20, bottom: 5 }}>
@@ -808,7 +884,12 @@ export default function AgentMonitorPage() {
           </ChartContainer>
         )}
         {!avgResponseTimesLoading && !avgResponseTimesError && avgResponseTimesData.length === 0 && (
-          <p className="text-center py-10 text-muted-foreground">No data available for the selected filters.</p>
+          <EmptyStateDisplay
+            icon={LineChart}
+            title="Nenhum Tempo de Resposta"
+            message="Nenhum dado de tempo médio de resposta disponível para os filtros selecionados."
+            suggestion="Tente ajustar os filtros ou aguarde novos dados."
+          />
         )}
       </div>
 
@@ -819,9 +900,32 @@ export default function AgentMonitorPage() {
             <h2 className="text-xl font-semibold">Trace Details for ID: {currentTraceId}</h2>
             <Button variant="outline" size="sm" onClick={() => { setCurrentTraceId(''); setTraceData([]); setTraceError(null); }}>Clear Trace</Button>
           </div>
-          {traceLoading && <p className="text-center py-10">Loading trace details...</p>}
-          {traceError && <p className="text-red-500 text-center py-10">Error loading trace: {traceError}</p>}
-          {!traceLoading && !traceError && traceData.length > 0 && (
+          {traceLoading ? (
+            <div className="overflow-x-auto">
+              <table className="min-w-full"> {/* Use table-fixed if desired, but might not be necessary for skeletons */}
+                <thead className="bg-muted/50">
+                  <tr>
+                    <th scope="col" className="w-[200px] px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Timestamp</th>
+                    <th scope="col" className="w-[100px] px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Type</th>
+                    <th scope="col" className="w-[250px] px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Flow / Agent</th>
+                    <th scope="col" className="px-4 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Details</th>
+                  </tr>
+                </thead>
+                <tbody className="bg-background divide-y divide-border">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <tr key={`skel-trace-${index}`}>
+                      <td className="px-4 py-3"><Skeleton className="h-5 w-3/4" /></td>
+                      <td className="px-4 py-3"><Skeleton className="h-5 w-20" /></td>
+                      <td className="px-4 py-3"><Skeleton className="h-5 w-5/6" /></td>
+                      <td className="px-4 py-3"><Skeleton className="h-5 w-full" /></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : traceError ? (
+            <p className="text-red-500 text-center py-10">Error loading trace: {traceError}</p>
+          ) : traceData.length > 0 ? (
             <div className="overflow-x-auto">
               <table className="min-w-full divide-y divide-border table-fixed">
                 <thead className="bg-muted/50">
@@ -885,24 +989,43 @@ export default function AgentMonitorPage() {
             </div>
           )}
           {!traceLoading && !traceError && currentTraceId && traceData.length === 0 && (
-            <p className="text-center py-10 text-muted-foreground">No logs found for Trace ID: {currentTraceId}</p>
+            <EmptyStateDisplay
+              icon={FileQuestion}
+              title="Nenhum Detalhe de Trace"
+              message={`Nenhum log encontrado para o Trace ID: ${currentTraceId}.`}
+              suggestion="Verifique o ID do trace ou tente um diferente."
+            />
           )}
         </div>
       )}
 
       <div className="bg-card p-6 rounded-lg shadow mb-8">
         <h2 className="text-xl font-semibold mb-4">Log Viewer</h2>
-        <p>Raw logs with filtering and pagination will be displayed here.</p>
+        <EmptyStateDisplay
+          icon={ScrollText}
+          title="Visualizador de Logs"
+          message="Os logs brutos com filtros e paginação serão exibidos aqui assim que a funcionalidade for implementada."
+        />
       </div>
 
       <div className="bg-card p-6 rounded-lg shadow mb-8"> {/* Added mb-8 for spacing */}
-        <h2 className="text-xl font-semibold mb-4">Log Viewer</h2>
-        <p className="text-muted-foreground">Raw logs with filtering and pagination will be displayed here. (Functionality to be fully implemented based on API)</p>
+        <h2 className="text-xl font-semibold mb-4">Log Viewer (Alternativo)</h2> {/* Renamed title for clarity if they are different sections */}
+         <EmptyStateDisplay
+          icon={Inbox} // Using a different icon for variety if this is a distinct section
+          title="Visualizador de Logs Detalhado"
+          message="Uma visualização mais detalhada dos logs, possivelmente com análise avançada, aparecerá aqui."
+          suggestion="Funcionalidade a ser implementada com base na API de logs."
+        />
       </div>
 
       <div className="bg-card p-6 rounded-lg shadow">
         <h2 className="text-xl font-semibold mb-4">Detailed Statistics (API Driven)</h2>
-        <p className="text-muted-foreground">Specific metrics like usage frequency, error rates, and response times based on actual log data will be shown here once API calls are fully filtered and connected to these charts.</p>
+        <EmptyStateDisplay
+          icon={Table2}
+          title="Estatísticas Detalhadas"
+          message="Métricas específicas baseadas em dados de log reais serão exibidas aqui quando a integração API estiver completa."
+          suggestion="Aguarde a implementação completa da API para visualização de dados."
+        />
       </div>
     </div>
   );

--- a/src/app/api-key-vault/page.tsx
+++ b/src/app/api-key-vault/page.tsx
@@ -71,6 +71,7 @@ import {
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { ApiKeyVaultEntry } from "@/types/apiKeyVaultTypes"; // Import the main type
+import { Skeleton } from "@/components/ui/skeleton"; // Import Skeleton
 
 // Use ApiKeyVaultEntry directly
 const initialApiKeys: ApiKeyVaultEntry[] = [];
@@ -89,6 +90,7 @@ const SERVICE_TYPE_OPTIONS = [
 
 export default function ApiKeyVaultPage() {
   const [apiKeys, setApiKeys] = React.useState<ApiKeyVaultEntry[]>(initialApiKeys);
+  const [isLoadingApiKeys, setIsLoadingApiKeys] = React.useState(true); // Added loading state
   const [isAddKeyDialogOpen, setIsAddKeyDialogOpen] = React.useState(false);
 
   // RHF for "Add New Key" Dialog
@@ -312,6 +314,7 @@ export default function ApiKeyVaultPage() {
 
   React.useEffect(() => {
     const fetchKeys = async () => {
+      setIsLoadingApiKeys(true); // Set loading true at the start
       try {
         const response = await fetch("/api/apikeys");
         if (!response.ok) {
@@ -328,6 +331,8 @@ export default function ApiKeyVaultPage() {
         console.error("Failed to fetch API keys:", error);
         setApiKeys([]); // Ensure it's an empty array on error
         // toast({ title: "Erro ao Carregar", description: "Não foi possível carregar as configurações de chave API.", variant: "destructive" });
+      } finally {
+        setIsLoadingApiKeys(false); // Set loading false in finally block
       }
     };
     fetchKeys();
@@ -458,10 +463,40 @@ export default function ApiKeyVaultPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {apiKeys.length === 0 ? (
+              {isLoadingApiKeys ? (
+                Array.from({ length: 4 }).map((_, index) => (
+                  <TableRow key={`skeleton-${index}`}>
+                    <TableCell><Skeleton className="h-5 w-3/4" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-1/2" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-1/4" /></TableCell>
+                    <TableCell><Skeleton className="h-5 w-1/4" /></TableCell>
+                    <TableCell className="text-right space-x-1">
+                      <div className="flex justify-end space-x-2">
+                        <Skeleton className="h-8 w-8" />
+                        <Skeleton className="h-8 w-8" />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              ) : apiKeys.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={5} className="text-center text-muted-foreground py-8">
-                    Nenhuma configuração de chave API registrada ainda.
+                  <TableCell colSpan={5} className="py-10 md:py-16">
+                    <div className="flex flex-col items-center justify-center space-y-3 text-center">
+                      <KeyRound className="h-16 w-16 text-muted-foreground/70" />
+                      <h2 className="text-xl font-medium text-foreground">
+                        Nenhuma Chave API Configurada
+                      </h2>
+                      <p className="text-sm text-muted-foreground max-w-md">
+                        As chaves API permitem que seus agentes se conectem e interajam com serviços externos. Adicione sua primeira chave para começar.
+                      </p>
+                      <Button onClick={() => {
+                        addKeyMethods.reset(); // Ensure form is reset
+                        setIsAddKeyDialogOpen(true);
+                      }} className="mt-2">
+                        <PlusCircle className="mr-2 h-4 w-4" />
+                        Adicionar Chave API
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               ) : (

--- a/src/components/features/agent-builder/agent-builder-dialog.tsx
+++ b/src/components/features/agent-builder/agent-builder-dialog.tsx
@@ -12,6 +12,7 @@ import {
   DialogFooter,
   DialogClose
 } from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge'; // Import Badge
 import { Button } from '@/components/ui/button';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
@@ -53,6 +54,7 @@ import {
   Settings2,
   Loader2,
   ClipboardCopy,
+  Undo2, // Import Undo2
   // Wand2 // Already imported
 } from 'lucide-react';
 
@@ -398,9 +400,16 @@ const AgentBuilderDialog: React.FC<AgentBuilderDialogProps> = ({
         <FormProvider {...methods}>
           <form onSubmit={methods.handleSubmit(onSubmit)}>
             <DialogHeader className="p-6 pb-4 border-b">
-              <DialogTitle>{editingAgent ? "Editar Agente IA" : "Criar Novo Agente IA"}</DialogTitle>
+              <div className="flex items-center">
+                <DialogTitle>{editingAgent ? "Editar Agente IA" : "Criar Novo Agente IA"}</DialogTitle>
+                {editingAgent && (
+                  <Badge variant="outline" className="ml-3 text-sm">
+                    Editando: {editingAgent.agentName}
+                  </Badge>
+                )}
+              </div>
               <DialogDescription>
-                {editingAgent ? `Modifique as configurações do agente "${editingAgent.agentName}".` : "Configure um novo agente inteligente para suas tarefas."}
+                {editingAgent ? `Modifique as configurações do agente.` : "Configure um novo agente inteligente para suas tarefas."}
               </DialogDescription>
               <input
                 type="file"
@@ -794,6 +803,23 @@ const AgentBuilderDialog: React.FC<AgentBuilderDialogProps> = ({
                   <DialogClose asChild>
                     <Button variant="outline" type="button">Cancelar</Button>
                   </DialogClose>
+                  <Button
+                    variant="outline"
+                    type="button"
+                    onClick={() => {
+                      if (editingAgent) {
+                        methods.reset(prepareFormDefaultValues(editingAgent));
+                        toast({
+                          title: "Alterações Revertidas",
+                          description: "Os dados do formulário foram revertidos para o original.",
+                        });
+                      }
+                    }}
+                    className="mr-2" // Added margin for spacing
+                  >
+                    <Undo2 className="mr-2 h-4 w-4" />
+                    Reverter
+                  </Button>
                   <Button type="submit" disabled={!methods.formState.isValid || methods.formState.isSubmitting}>
                     {methods.formState.isSubmitting ? (
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/features/agent-builder/tool-card.tsx
+++ b/src/components/features/agent-builder/tool-card.tsx
@@ -5,6 +5,7 @@ import { Check, Settings } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { AvailableTool } from "@/types/tool-types";
 
@@ -22,9 +23,12 @@ export const ToolCard: React.FC<ToolCardProps> = ({
   onConfigure,
 }) => {
   return (
-    <Card
-      className={cn(
-        "border transition-all duration-200 hover:border-primary/50 cursor-pointer relative",
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Card
+            className={cn(
+              "border transition-all duration-200 hover:border-primary/50 cursor-pointer relative",
         isSelected ? "border-primary ring-1 ring-primary" : "border-border",
         tool.isMCPTool
           ? "bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-950 dark:to-slate-900"
@@ -83,5 +87,29 @@ export const ToolCard: React.FC<ToolCardProps> = ({
         )}
       </CardContent>
     </Card>
-  );
+  </TooltipTrigger>
+  <TooltipContent className="w-80">
+    <p className="text-sm font-semibold">{tool.name}</p>
+    <p className="text-xs text-muted-foreground mb-2">{tool.description}</p>
+    {/* Assuming tool.parameters might exist on the AvailableTool type */}
+    {tool.parameters && tool.parameters.length > 0 && (
+      <div className="mt-2 pt-2 border-t border-border">
+        <p className="text-xs font-medium mb-1">Parameters:</p>
+        <ul className="list-none p-0 space-y-1">
+          {tool.parameters.map((param: any) => ( // Add 'any' type for param if not defined in AvailableTool
+            <li key={param.name}>
+              <p className="text-xs font-semibold">
+                {param.name}
+                {param.type && <span className="text-muted-foreground font-normal ml-1">({param.type})</span>}
+              </p>
+              {param.description && <p className="text-xs text-muted-foreground">{param.description}</p>}
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+  </TooltipContent>
+</Tooltip>
+</TooltipProvider>
+);
 };

--- a/src/components/features/chat/ConversationSidebar.tsx
+++ b/src/components/features/chat/ConversationSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from "react";
 import { Conversation } from "@/types/chat";
 import { cn } from "@/lib/utils";
 import type { Gem, SavedAgentConfiguration as SavedAgentConfigType } from "@/data/agentBuilderConfig"; // Use SavedAgentConfigType alias
+import { MessageSquarePlus } from "lucide-react"; // Import the icon
 
 // TODO: Move AgentSelectItem to a shared types file
 interface AgentSelectItem {
@@ -190,13 +191,19 @@ export function ConversationSidebar({
             </button>
 
             {/* Conversation List */}
-            <div className="flex-1 overflow-y-auto custom-scrollbar-dark -mr-2 pr-2">
+            <div className="flex-1 overflow-y-auto custom-scrollbar-dark -mr-2 pr-2 flex flex-col">
               {" "}
-              {/* Negative margin for scrollbar */}
+              {/* Negative margin for scrollbar, and flex for centering empty state */}
               {conversations.length === 0 ? (
-                <p className="text-sm text-gray-400 text-center mt-4">
-                  No chats yet. Click 'New Chat' to start.
-                </p>
+                <div className="flex-grow flex flex-col items-center justify-center text-center p-4">
+                  <MessageSquarePlus className="w-12 h-12 text-gray-500 mb-3" />
+                  <h3 className="text-md font-semibold text-gray-300 mb-1">
+                    Inicie uma Nova Conversa
+                  </h3>
+                  <p className="text-sm text-gray-400">
+                    Clique no botão "New Chat" acima para começar um novo diálogo.
+                  </p>
+                </div>
               ) : (
                 <ul className="space-y-1">
                   {conversations.map((conv) => (

--- a/src/components/features/chat/MessageList.tsx
+++ b/src/components/features/chat/MessageList.tsx
@@ -1,6 +1,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import { Bot } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { Skeleton } from '@/components/ui/skeleton'; // Import Skeleton
 import { ChatMessageUI } from '@/types/chat';
 import { forwardRef, useRef, useEffect } from 'react';
 import SimplerChatMessage from './SimplerChatMessage';
@@ -93,23 +94,18 @@ const MessageList = forwardRef<HTMLDivElement, MessageListProps>(({
               className={cn("flex items-end gap-2.5 justify-start w-full")}
             >
               <div className="flex-shrink-0 p-1.5 rounded-full bg-card border border-border/50 self-start">
-                <Bot className="h-5 w-5 text-primary animate-pulse" />
+                <Bot className="h-5 w-5 text-primary" />
               </div>
-              <div className="p-3 rounded-lg bg-card max-w-[70%] shadow-sm rounded-bl-none border border-border/50">
-                <span className="flex gap-1 items-center text-sm text-muted-foreground animate-pulse">
-                  <span>D</span>
-                  <span>i</span>
-                  <span>g</span>
-                  <span>i</span>
-                  <span>t</span>
-                  <span>a</span>
-                  <span>n</span>
-                  <span>d</span>
-                  <span>o</span>
+              <div className="p-3 rounded-lg bg-card max-w-[70%] shadow-sm rounded-bl-none border border-border/50 space-y-2">
+                <Skeleton className="h-4 w-4/5" />
+                <Skeleton className="h-4 w-3/5" />
+                {/* Optional: Keep "Digitando..." alongside or remove if Skeleton is enough */}
+                {/* <span className="flex gap-1 items-center text-xs text-muted-foreground/80 animate-pulse">
+                  <span>D</span><span>i</span><span>g</span><span>i</span><span>t</span><span>a</span><span>n</span><span>d</span><span>o</span>
                   <span className="animate-bounce" style={{ animationDelay: "0s" }}>.</span>
                   <span className="animate-bounce" style={{ animationDelay: "0.15s" }}>.</span>
                   <span className="animate-bounce" style={{ animationDelay: "0.3s" }}>.</span>
-                </span>
+                </span> */}
               </div>
             </motion.div>
           )}


### PR DESCRIPTION
This commit introduces several UX improvements across the application as per Bloco 2 tasks:

1.  **Task 4: Tooltip on ToolCard:**
    - Added tooltips to ToolCards in `agent-builder/tool-card.tsx`.
    - Tooltips display the tool's full description and parameters (if any) on hover, improving discoverability.

2.  **Task 5: Attractive and Useful Empty States:**
    - Enhanced empty state messages in: - `agent-builder/page.tsx` (for no agents) - `api-key-vault/page.tsx` (for no API keys) - `features/chat/ConversationSidebar.tsx` (for no conversations) - `agent-monitor/page.tsx` (for various data sections)
    - Empty states now include icons, more engaging messages, and clear calls-to-action.
    - A reusable `EmptyStateDisplay` component was created in `agent-monitor/page.tsx` for consistency.

3.  **Task 6: Loading Skeletons:**
    - Implemented skeleton loading UIs in: - `agent-builder/page.tsx` (for agent cards) - `api-key-vault/page.tsx` (for API keys table) - `features/chat/MessageList.tsx` (for pending messages) - `agent-monitor/page.tsx` (for charts and tables)
    - Skeletons provide better visual feedback during data loading.

4.  **Task 7: Agent Editing Dialog Enhancements:**
    - Improved the agent editing dialog in `agent-builder/agent-builder-dialog.tsx`: - Added a badge in the header: "Editando: [Nome do Agente]" when editing. - Added a "Reverter Alterações" button in the footer that resets form changes to their original state and shows a confirmation toast.