### PR TITLE
feat(agent-builder): Enhance system prompt generation and editing

### DIFF
--- a/src/data/available-tools.ts
+++ b/src/data/available-tools.ts
@@ -18,6 +18,16 @@ export const availableTools: AvailableTool[] = [
     ],
     requiresAuth: true,
     serviceTypeRequired: "Google Search",
+    inputSchema: `{
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": "The search query."
+        }
+      },
+      "required": ["query"]
+    }`
   },
   {
     id: 'openapi-custom',
@@ -34,6 +44,20 @@ export const availableTools: AvailableTool[] = [
     ],
     requiresAuth: true, // Assuming most OpenAPI specs might need auth
     serviceTypeRequired: "Custom API", // Or could be more specific if known
+    inputSchema: `{
+      "type": "object",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "description": "The specific API endpoint to call."
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Parameters to pass to the API endpoint."
+        }
+      },
+      "required": ["endpoint"]
+    }`
   },
   {
     id: 'database-connector',
@@ -55,6 +79,21 @@ export const availableTools: AvailableTool[] = [
     ],
     requiresAuth: true, // Assuming credentials might be sensitive and stored in vault
     serviceTypeRequired: "Database",
+    inputSchema: `{
+      "type": "object",
+      "properties": {
+        "sql_query": {
+          "type": "string",
+          "description": "The SQL query to execute."
+        },
+        "params": {
+          "type": "array",
+          "description": "Parameters for the SQL query.",
+          "items": { "type": "any" }
+        }
+      },
+      "required": ["sql_query"]
+    }`
   },
   {
     id: 'simple-calculator',
@@ -67,6 +106,16 @@ export const availableTools: AvailableTool[] = [
     hasConfig: false,
     requiresAuth: false,
     serviceTypeRequired: "N/A",
+    inputSchema: `{
+      "type": "object",
+      "properties": {
+        "expression": {
+          "type": "string",
+          "description": "The mathematical expression to evaluate."
+        }
+      },
+      "required": ["expression"]
+    }`
   },
   {
     id: 'chat-tool',

--- a/src/lib/zod-schemas.ts
+++ b/src/lib/zod-schemas.ts
@@ -11,6 +11,9 @@ import type {
   CommunicationChannel as CommunicationChannelType // For A2A
 } from '@/types/agent-configs-new';
 
+// Maximum length for system prompts
+export const MAX_SYSTEM_PROMPT_LENGTH = 10000;
+
 // Enums defined from TypeScript types
 const AgentFrameworkEnum = z.enum(["genkit", "crewai", "langchain", "custom", "none"]);
 const AgentTypeEnum = z.enum(["llm", "workflow", "custom", "a2a"]);
@@ -150,11 +153,24 @@ export const agentConfigBaseSharedSchema = z.object({
   statePersistence: statePersistenceConfigSchema.optional(),
   ragMemoryConfig: ragMemoryConfigSchema.optional(),
   artifacts: artifactsConfigSchema.optional(),
+  systemPromptGenerated: z.string().optional().refine(
+    (val) => val === undefined || val === null || val.length <= MAX_SYSTEM_PROMPT_LENGTH,
+    { message: `O prompt gerado excede o limite de ${MAX_SYSTEM_PROMPT_LENGTH} caracteres.` }
+  ),
+  manualSystemPromptOverride: z.string().optional().refine(
+    (val) => val === undefined || val === null || val.length <= MAX_SYSTEM_PROMPT_LENGTH,
+    { message: `O prompt manual excede o limite de ${MAX_SYSTEM_PROMPT_LENGTH} caracteres.` }
+  ),
   a2a: a2aSettingsSchema.optional(),
   isRootAgent: z.boolean().optional().default(true),
   subAgentIds: z.array(z.string()).optional(),
   globalInstruction: z.string().optional(),
+  sandboxedCodeExecution: z.boolean().optional(), // Added from AgentConfigBase in types
   adkCallbacks: adkCallbacksConfigSchema, // Added ADK Callbacks here
+  systemPromptHistory: z.array(z.object({
+    prompt: z.string(),
+    timestamp: z.string().datetime(),
+  })).optional(),
 });
 
 export const llmAgentConfigSchema = agentConfigBaseSharedSchema.extend({

--- a/src/types/agent-configs-new.ts
+++ b/src/types/agent-configs-new.ts
@@ -119,7 +119,9 @@ export interface AgentConfigBase {
   ragMemoryConfig?: RagMemoryConfig;
   artifacts?: ArtifactsConfig;
   systemPromptGenerated?: string; // Added field for auto-generated system prompt
+  manualSystemPromptOverride?: string; // Manually overridden system prompt
   sandboxedCodeExecution?: boolean;
+  systemPromptHistory?: Array<{ prompt: string; timestamp: string }>; // History of system prompts
 }
 
 export interface ModelSafetySettingItem {


### PR DESCRIPTION
This commit implements Bloco 10, improving control and clarity over the system prompt for LLM Agents.

Key features added:

1.  **Interactive Prompt Previewer (10.1):** A read-only preview of the generated system prompt is now displayed in real-time in the "Behavior" tab as your agent configuration (goal, tasks, tools, etc.) changes.

2.  **Manual Prompt Editing with Reset (10.2):** You can now manually edit the system prompt. An "Edit" button enables a textarea for modifications. A "Reset to Auto-generated" button discards manual changes and reverts to the dynamically generated prompt.

3.  **System Prompt Size Validation (10.3):** The system prompt (both auto-generated and manual) is validated against a maximum character length (10,000 chars). You are notified via error messages and a character counter.

4.  **Syntax Highlighting for Previewer (10.4):** The read-only prompt previewer now uses syntax highlighting (Markdown) for improved legibility, switching to a standard textarea for manual editing.

5.  **Tool Usage Snippets in Prompt (10.5):** The `constructSystemPrompt` function now includes descriptions and usage snippets (e.g., `tool_name(param1: type, param2?: type)`) for selected tools, derived from their `inputSchema`.

6.  **Tooltips for Prompt Fields (10.6):** Informative tooltips have been added to `agentGoal`, `agentTasks`, `agentPersonality`, and `agentRestrictions` fields, explaining their contribution to the system prompt.

7.  **Simple Prompt Version History (10.7):** The last 3 versions of the system prompt are saved with the agent configuration. You can view this history and restore a previous version into the manual editor.

These changes provide you with significantly more visibility and control over the final system prompt used by the LLM agent.