### PR TITLE
I've made some progress on implementing basic MCP Tool support:

### DIFF
--- a/src/components/features/agent-builder/ToolsTab.tsx
+++ b/src/components/features/agent-builder/ToolsTab.tsx
@@ -7,24 +7,27 @@ import { TabsContent } from "@/components/ui/tabs"; // Needed for the root eleme
 import ToolCard from "./ToolCard";
 import type { AvailableTool } from "@/types/agent-types";
 import type { ToolConfigData } from '@/types/agent-configs-fixed';
+import type { MCPServerConfig } from '@/types/mcp-types'; // Import MCPServerConfig
 
 // Props para o componente ToolsTab.
 interface ToolsTabProps {
   availableTools: AvailableTool[];
+  mcpServers?: MCPServerConfig[]; // Add mcpServers prop
   selectedTools: string[];
-  setSelectedTools: React.Dispatch<React.SetStateAction<string[]>>; // Allows direct update of selected tools
-  toolConfigurations: Record<string, ToolConfigData>;
-  handleToolConfigure: (tool: AvailableTool) => void; // Function to open configuration modal
+  setSelectedTools: React.Dispatch<React.SetStateAction<string[]>>;
+  toolConfigurations: Record<string, ToolConfigData>; // This should now potentially include selectedMcpServerId
+  handleToolConfigure: (tool: AvailableTool) => void;
   iconComponents: Record<string, React.FC<React.SVGProps<SVGSVGElement>>>;
-  Wand2Icon: React.FC<React.SVGProps<SVGSVGElement>>; // Actual Wand2 component
-  SettingsIcon: React.FC<React.SVGProps<SVGSVGElement>>; // Actual Settings component
-  CheckIcon: React.FC<React.SVGProps<SVGSVGElement>>; // Actual Check component
-  AlertIcon: React.FC<React.SVGProps<SVGSVGElement>>; // Icon for the Alert (e.g., Wand2)
-  isSequentialWorkflow?: boolean; // MODIFIED: Added prop
+  Wand2Icon: React.FC<React.SVGProps<SVGSVGElement>>;
+  SettingsIcon: React.FC<React.SVGProps<SVGSVGElement>>;
+  CheckIcon: React.FC<React.SVGProps<SVGSVGElement>>;
+  AlertIcon: React.FC<React.SVGProps<SVGSVGElement>>;
+  isSequentialWorkflow?: boolean;
 }
 
 const ToolsTab: React.FC<ToolsTabProps> = ({
   availableTools,
+  mcpServers, // Destructure mcpServers
   selectedTools,
   setSelectedTools,
   toolConfigurations,

--- a/src/components/features/agent-builder/agent-builder-dialog.tsx
+++ b/src/components/features/agent-builder/agent-builder-dialog.tsx
@@ -218,7 +218,7 @@ import type {
   // Add any other specific config types that were imported from agent-configs-fixed if they were missed
   // For example, if WorkflowDetailedType, TerminationConditionType etc. were used here, they would be added.
   // For now, sticking to the explicitly mentioned ones and those directly replacing the old imports.
-
+  MCPServerConfig, // Added for MCP Server mock data
 } from '@/types/agent-types';
 // Import WorkflowStep directly from agent-configs-new
 import { WorkflowStep } from '@/types/agent-configs-new';
@@ -700,7 +700,16 @@ interface AgentBuilderDialogProps {
   agentToneOptions: string[];
   iconComponents: Record<string, React.ComponentType>;
   availableAgentsForSubSelector: Array<{ id: string; agentName: string }>;
+  mcpServers?: MCPServerConfig[]; // Prop if passed from parent, otherwise mock
+  onConfigureToolInDialog: (tool: AvailableTool) => void; // New prop from AgentBuilderPage
 }
+
+// Mock MCP Servers data for now
+const mockMcpServers: MCPServerConfig[] = [
+  { id: 'mcp-server-1', name: 'MCP Server Alpha', url: 'https://mcp.example.com/alpha', description: 'Primary MCP processing server.' },
+  { id: 'mcp-server-2', name: 'MCP Server Beta (Experimental)', url: 'https://mcp.example.com/beta', description: 'Experimental MCP server with new features.' },
+  { id: 'mcp-server-3', name: 'MCP Server Gamma (Legacy)', url: 'https://mcp.example.com/gamma', description: 'Legacy MCP server for specific tools.' },
+];
 
 const AgentBuilderDialog: React.FC<AgentBuilderDialogProps> = ({
   isOpen,
@@ -712,6 +721,8 @@ const AgentBuilderDialog: React.FC<AgentBuilderDialogProps> = ({
   agentToneOptions,
   iconComponents,
   availableAgentsForSubSelector,
+  mcpServers = mockMcpServers, // Use prop or default to mock
+  onConfigureToolInDialog, // Destructure the new prop
 }) => {
   const { apiKeys: availableApiKeys, isLoading: apiKeysLoading, error: apiKeysError } = useApiKeyVault();
   // TODO: Handle apiKeysLoading and apiKeysError appropriately
@@ -1500,15 +1511,17 @@ const AgentBuilderDialog: React.FC<AgentBuilderDialogProps> = ({
                   <Suspense fallback={<LoadingFallback />}>
                     <ToolsTab
                       availableTools={availableTools}
-                      // selectedTools, setSelectedTools, toolConfigurations, setToolConfiguration are managed by useFormContext in ToolsTab
+                      // selectedTools, setSelectedTools, toolConfigurations are from useFormContext
+                      handleToolConfigure={onConfigureToolInDialog} // Pass the handler to ToolsTab
                       iconComponents={iconComponents}
-                      InfoIconComponent={InfoIcon} // Pass the imported InfoIcon, ToolsTab expects InfoIconComponent
+                      InfoIconComponent={InfoIcon}
                       SettingsIcon={Settings}
-                    CheckIcon={Check}
-                    PlusCircleIcon={PlusCircle} // Keep passing for now, ToolsTabProps includes it
-                    Trash2Icon={Trash2} // Keep passing for now, ToolsTabProps includes it
-                    showHelpModal={showHelpModal}
-                    availableApiKeys={availableApiKeys || []}
+                      CheckIcon={Check}
+                      PlusCircleIcon={PlusCircle}
+                      Trash2Icon={Trash2}
+                      showHelpModal={showHelpModal}
+                      availableApiKeys={availableApiKeys || []}
+                      mcpServers={mcpServers} // Pass mcpServers from props (which defaults to mockMcpServers)
                     />
                   </Suspense>
                 </TabsContent>

--- a/src/types/agent-configs-fixed.ts
+++ b/src/types/agent-configs-fixed.ts
@@ -45,6 +45,7 @@ export interface ToolConfigField {
 export interface ToolConfigData {
   [toolId: string]: {
     [fieldId: string]: string | number | boolean;
+    selectedMcpServerId?: string;
   };
 }
 

--- a/src/types/tool-types.ts
+++ b/src/types/tool-types.ts
@@ -65,9 +65,9 @@ export interface AvailableTool {
 
   // Campos específicos para MCP Tools
   isMCPTool?: boolean; 
-  mcpServerId?: string;
-  mcpServerName?: string;
-  mcpToolName?: string;
+  // mcpServerId?: string; // Removed - This will be part of ToolConfigData
+  // mcpServerName?: string; // Removed - This was likely for display and not persisted on the tool definition
+  mcpToolName?: string; // This might be the specific name/ID the MCP server expects for this tool
   parameters?: ToolParameter[];
 
   // Campos para configuração da UI


### PR DESCRIPTION
- I've added UI for selecting an `mcpServerId` in the ToolConfigModal for MCP tools.
- I've updated `chat-flow.ts` to simulate MCP tool invocations for configured MCP tools, logging the call and returning a mock response.
- I've refined `tool-types.ts` and related components to correctly store and identify MCP tool configurations.