### PR TITLE
feat: Implement Bloco 20 Continuide e Ecossistema tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "nextn",
   "version": "0.1.0",
   "private": true,
+  // Conceptual note: src/components/ui/ could be a candidate for a separate UI library package.
+  // "uiLibraryCandidatePath": "src/components/ui",
   "scripts": {
     "dev": "set NODE_OPTIONS=--inspect=0.0.0.0:9231 && next dev --turbopack -p 9005",
     "dev:stable": "next dev --turbopack -p 9002",

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as React from 'react';
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
+import { Button } from '@/components/ui/button'; // For potential future use, not strictly needed for links
+import { Users, BookOpen, Lightbulb, MessageSquare, FileText, Youtube, Users2, PackageSearch } from 'lucide-react'; // Import appropriate icons
+import Link from 'next/link'; // For internal links like /marketplace
+
+// Define a type for link items for easier mapping
+interface CommunityLink {
+  href: string;
+  text: string;
+  icon?: React.ElementType;
+  isInternal?: boolean;
+}
+
+interface LinkSection {
+  title: string;
+  icon?: React.ElementType;
+  links: CommunityLink[];
+}
+
+const communitySections: LinkSection[] = [
+  {
+    title: "Recursos da Comunidade",
+    icon: Users2,
+    links: [
+      { href: "#", text: "Fórum Oficial ADK", icon: MessageSquare },
+      { href: "/docs", text: "Documentação Detalhada do ADK", icon: BookOpen, isInternal: true }, // Assuming /docs could be an internal route
+      { href: "#", text: "Blog da Comunidade ADK", icon: FileText },
+      { href: "#", text: "Servidor Discord da Comunidade", icon: Users },
+    ],
+  },
+  {
+    title: "Tutoriais e Guias da Comunidade",
+    icon: BookOpen,
+    links: [
+      { href: "#", text: "Tutorial: Construindo seu Primeiro Agente com ADK (Vídeo)", icon: Youtube },
+      { href: "#", text: "Guia Avançado: Integrando Ferramentas Customizadas no ADK", icon: FileText },
+      { href: "#", text: "Melhores Práticas para Design de Agentes Colaborativos", icon: Users2 },
+    ],
+  },
+  {
+    title: "Exemplos de Agentes e Projetos",
+    icon: Lightbulb,
+    links: [
+      { href: "/marketplace", text: "Galeria de Agentes da Comunidade (Marketplace)", icon: PackageSearch, isInternal: true },
+      { href: "#", text: "Projeto Exemplo: Agente de Suporte ao Cliente com RAG", icon: Lightbulb },
+      { href: "#", text: "Projeto Exemplo: Agente de Análise de Dados Financeiros", icon: Lightbulb },
+    ],
+  },
+];
+
+export default function CommunityPage() {
+  return (
+    <main className="container mx-auto py-8 px-4 md:px-6">
+      <header className="mb-10 text-center">
+        <h1 className="text-4xl font-bold tracking-tight text-foreground sm:text-5xl">
+          Comunidade Agent Development Kit (ADK)
+        </h1>
+        <p className="mt-4 text-lg text-muted-foreground max-w-2xl mx-auto">
+          Explore recursos, tutoriais e exemplos criados pela comunidade ADK para aprimorar suas habilidades e descobrir novas possibilidades com agentes inteligentes.
+        </p>
+      </header>
+
+      <div className="space-y-12">
+        {communitySections.map((section) => (
+          <section key={section.title}>
+            <Card className="bg-card/50 backdrop-blur-lg">
+              <CardHeader className="pb-4">
+                <div className="flex items-center">
+                  {section.icon && <section.icon className="w-7 h-7 mr-3 text-primary" />}
+                  <CardTitle className="text-2xl font-semibold">{section.title}</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {section.links.map((link) => (
+                    <Card key={link.text} className="hover:shadow-md transition-shadow">
+                      <CardHeader className="flex flex-row items-center space-x-3 p-4">
+                        {link.icon && <link.icon className="w-5 h-5 text-muted-foreground flex-shrink-0" />}
+                        <div className="flex-1 min-w-0">
+                           {link.isInternal ? (
+                            <Link href={link.href} passHref>
+                              <span className="font-medium text-foreground hover:text-primary cursor-pointer truncate block">
+                                {link.text}
+                              </span>
+                            </Link>
+                          ) : (
+                            <a
+                              href={link.href}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="font-medium text-foreground hover:text-primary cursor-pointer truncate block"
+                            >
+                              {link.text}
+                            </a>
+                          )}
+                        </div>
+                      </CardHeader>
+                    </Card>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/marketplace/page.tsx
+++ b/src/app/marketplace/page.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { useToast } from '@/hooks/use-toast';
+import { Cpu, MessageSquareText, BarChart3, Icon as LucideIcon, Store, LayoutGrid, ShoppingBag, HelpCircle } from 'lucide-react';
+import { v4 as uuidv4 } from 'uuid';
+import type { SavedAgentConfiguration, AgentConfig, AgentFramework, AvailableTool } from '@/types/agent-types'; // Adjusted imports
+
+// Helper to get icon component
+const iconMap: Record<string, LucideIcon> = {
+  MessageSquareText,
+  BarChart3,
+  Cpu,
+  Default: HelpCircle, // Fallback icon
+};
+
+const getIconComponent = (iconName?: string): React.ReactNode => {
+  const Icon = iconName ? iconMap[iconName] : iconMap.Default;
+  return Icon ? <Icon className="w-8 h-8 mr-4 text-primary" /> : <HelpCircle className="w-8 h-8 mr-4 text-primary" />;
+};
+
+
+interface MarketplaceAgent extends Partial<SavedAgentConfiguration> {
+  isTemplate?: boolean;
+  tags?: string[];
+  icon?: string; // Icon name as string
+  // Ensure config is at least AgentConfig or a more specific type if possible
+  config: AgentConfig;
+  tools?: string[]; // Representing tool IDs
+}
+
+
+const mockMarketplaceAgents: MarketplaceAgent[] = [
+  {
+    id: 'template-chat-assistant-01', // This will be the template ID
+    agentName: 'Friendly Chatbot',
+    agentDescription: 'A simple chatbot for engaging conversations, powered by Gemini Flash.',
+    icon: 'MessageSquareText',
+    isTemplate: true,
+    config: {
+      agentType: 'llm', // Corrected: 'type' should be 'agentType' based on AgentConfig
+      framework: 'genkit' as AgentFramework,
+      agentName: 'Friendly Chatbot (Copy)', // Default name for installed copy
+      agentDescription: 'A simple chatbot for engaging conversations, powered by Gemini Flash.',
+      agentGoal: 'Be a friendly and helpful chatbot.',
+      agentModel: 'googleai/gemini-1.5-flash-latest',
+      agentPersonality: 'Friendly and approachable',
+      agentVersion: '1.0.0', // Added version
+      // agentTools: [], // tools are listed separately in MarketplaceAgent for clarity
+    } as AgentConfig, // Cast to base AgentConfig, specific types like LLMAgentConfig can be used if all fields are present
+    tools: [],
+    tags: ['chatbot', 'gemini', 'assistant'],
+  },
+  {
+    id: 'template-data-processor-01',
+    agentName: 'CSV Data Processor',
+    agentDescription: 'Analyzes CSV files to extract key information. Uses a calculator tool.',
+    icon: 'BarChart3',
+    isTemplate: true,
+    config: {
+      agentType: 'workflow',
+      framework: 'genkit' as AgentFramework,
+      agentName: 'CSV Data Processor (Copy)',
+      agentDescription: 'Analyzes CSV files to extract key information. Uses a calculator tool.',
+      agentGoal: 'Process CSV data and provide a summary.',
+      workflowDescription: '1. Load CSV. 2. Calculate column averages. 3. Output summary.',
+      agentVersion: '1.0.0',
+      // agentTools: ['calculator'],
+    } as AgentConfig,
+    tools: ['calculator'],
+    tags: ['data', 'csv', 'analyzer', 'workflow'],
+  },
+];
+
+const localStorageKey = 'userInstalledAgents';
+
+export default function MarketplacePage() {
+  const { toast } = useToast();
+  const [installedAgents, setInstalledAgents] = React.useState<Record<string, boolean>>({});
+
+  React.useEffect(() => {
+    // Check localStorage for already installed agents to update button states
+    const storedAgents = localStorage.getItem(localStorageKey);
+    if (storedAgents) {
+      try {
+        const parsedAgents: SavedAgentConfiguration[] = JSON.parse(storedAgents);
+        const installedMap: Record<string, boolean> = {};
+        parsedAgents.forEach(agent => {
+          if (agent.templateId) { // Assuming we store templateId when installing
+            installedMap[agent.templateId] = true;
+          }
+        });
+        setInstalledAgents(installedMap);
+      } catch (e) {
+        console.error("Failed to parse stored agents from localStorage", e);
+      }
+    }
+  }, []);
+
+  const handleInstallAgent = (templateAgent: MarketplaceAgent) => {
+    if (!templateAgent.id) {
+      toast({ title: 'Error', description: 'Template agent has no ID.', variant: 'destructive' });
+      return;
+    }
+
+    const newAgentId = uuidv4(); // Generate a unique ID for the new instance
+
+    // Create a new agent configuration based on the template
+    const newAgentConfig: SavedAgentConfiguration = {
+      ...templateAgent.config, // Spread the config from the template
+      id: newAgentId,          // Assign the new unique ID
+      templateId: templateAgent.id, // Store original template ID
+      agentName: templateAgent.config.agentName || `${templateAgent.agentName} (Installed)`, // Ensure agentName exists
+      agentDescription: templateAgent.config.agentDescription || templateAgent.agentDescription || '', // Ensure description
+      agentVersion: templateAgent.config.agentVersion || '1.0.0',
+      tools: templateAgent.tools || [], // Add tools to the root of SavedAgentConfiguration
+      toolsDetails: [], // Typically populated later or if detailed tool info is in template
+      toolConfigsApplied: {}, // Default empty config
+      // Ensure all required fields from SavedAgentConfiguration are present
+      agentType: templateAgent.config.agentType,
+      // framework: templateAgent.config.framework, // framework is not in SavedAgentConfiguration, it's part of AgentConfig
+    };
+
+    try {
+      const storedAgents = localStorage.getItem(localStorageKey);
+      const agentsList: SavedAgentConfiguration[] = storedAgents ? JSON.parse(storedAgents) : [];
+
+      // Check if an agent from this template ID was already installed (optional, good for UI)
+      // This specific check might be redundant if button is disabled, but good for robustness
+      const alreadyExists = agentsList.some(agent => agent.templateId === templateAgent.id && agent.id !== newAgentId);
+      if (alreadyExists && installedAgents[templateAgent.id]) {
+         // If we want to prevent re-installation from the same template shown in UI
+         // toast({ title: 'Already Installed', description: `An agent from template "${templateAgent.agentName}" is already installed.`, variant: 'default' });
+         // return;
+         // For now, let's allow multiple installs from the same template, each gets a new ID.
+      }
+
+      agentsList.push(newAgentConfig);
+      localStorage.setItem(localStorageKey, JSON.stringify(agentsList));
+
+      setInstalledAgents(prev => ({ ...prev, [templateAgent.id!]: true }));
+      toast({ title: 'Agent Installed', description: `"${newAgentConfig.agentName}" added to your agents.` });
+
+    } catch (error: any) {
+      console.error('Failed to install agent:', error);
+      toast({ title: 'Installation Failed', description: error.message || 'Could not save agent to local storage.', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <main className="container mx-auto py-8 px-4 md:px-6">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground">Agent Marketplace</h1>
+        <p className="text-muted-foreground mt-1">Discover and install ready-to-use agent templates.</p>
+      </header>
+
+      <section>
+        <h2 className="text-2xl font-semibold tracking-tight text-foreground mb-6">Agent Templates</h2>
+        {mockMarketplaceAgents.length > 0 ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {mockMarketplaceAgents.map((agent) => (
+              <Card key={agent.id} className="flex flex-col">
+                <CardHeader className="flex flex-row items-start">
+                  {getIconComponent(agent.icon)}
+                  <div>
+                    <CardTitle>{agent.agentName}</CardTitle>
+                    <CardDescription className="mt-1 line-clamp-3">{agent.agentDescription}</CardDescription>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex-grow">
+                  {/* <p className="text-sm text-muted-foreground">Version: {agent.config.agentVersion || 'N/A'}</p> */}
+                  {agent.tags && agent.tags.length > 0 && (
+                    <div className="mt-2">
+                      {agent.tags.map(tag => (
+                        <span key={tag} className="inline-block bg-secondary text-secondary-foreground text-xs px-2 py-1 rounded-full mr-1 mb-1">
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                   {agent.tools && agent.tools.length > 0 && (
+                    <div className="mt-3">
+                      <h4 className="text-sm font-medium text-foreground mb-1">Tools:</h4>
+                      <ul className="list-disc list-inside pl-1 text-sm text-muted-foreground">
+                        {agent.tools.map(toolId => <li key={toolId}>{toolId}</li>)}
+                      </ul>
+                    </div>
+                  )}
+                </CardContent>
+                <CardFooter>
+                  <Button
+                    onClick={() => handleInstallAgent(agent)}
+                    disabled={installedAgents[agent.id!]} // Disable if this template ID has been installed
+                    className="w-full"
+                  >
+                    {installedAgents[agent.id!] ? 'Installed' : 'Install Agent'}
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground">No agent templates available at the moment.</p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -19,6 +19,8 @@ import {
   SlidersHorizontal, // Icon for Ferramentas
   Cog, // Icon for Configurações group
   Languages, // Icon for Language Selector
+  Store, // Icon for Marketplace
+  Users2, // Icon for Community
 } from "lucide-react";
 import {
   Sidebar,
@@ -68,6 +70,8 @@ interface NavItem {
 const mainNavItems: NavItem[] = [
   { href: "/agent-builder", icon: Cpu, label: "Agentes" },
   { href: "/chat", icon: MessageSquare, label: "Chat" },
+  { href: "/marketplace", icon: Store, label: "Marketplace" },
+  { href: "/community", icon: Users2, label: "Comunidade" }, // Added Community
   { href: "/agent-monitor", icon: Activity, label: "Monitor" },
 ];
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+// Candidate for @agentverse/ui-components
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,3 +1,70 @@
-export * from './InfoIcon';
-export * from './HelpModal';
-// Add other exports here if any other components are in this directory
+// Entry point for potential UI library package.
+// All components intended for the package should be exported from here.
+
+// Core Shadcn-like Primitives
+export * from "./accordion";
+export * from "./alert-dialog";
+export * from "./alert";
+export * from "./avatar";
+export * from "./badge";
+export * from "./breadcrumb";
+export * from "./button";
+export * from "./calendar";
+export * from "./card";
+export * from "./checkbox";
+export * from "./command";
+export * from "./dialog";
+export * from "./dropdown-menu";
+export * from "./form"; // Provides Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, useFormField
+export * from "./input";
+export * from "./label";
+export * from "./menubar";
+export * from "./popover";
+export * from "./progress";
+export * from "./radio-group";
+export * from "./scroll-area";
+export * from "./select";
+export * from "./separator";
+export * from "./sheet";
+export * from "./skeleton";
+export * from "./slider";
+export * from "./switch";
+export * from "./table";
+export * from "./tabs";
+export * from "./textarea";
+export * from "./toast";
+export * from "./toaster";
+export * from "./tooltip";
+
+// Potentially Custom/Composite Components (candidates for inclusion)
+export * from "./InfoIcon"; // Assuming this is generic
+export * from "./JsonEditorField"; // Assuming this is generic
+export * from "./ConfirmationModal"; // Assuming this is a generic confirmation dialog wrapper
+export * from "./FileUploader"; // If generic enough
+export * from "./TagInput"; // If generic enough
+export * from "./spinner"; // If generic
+export * from "./HelpModal"; // If the shell is generic (e.g. using Dialog). Assuming HelpModal.tsx is canonical.
+// export * from "./OnboardingModal"; // Likely too app-specific unless very generic shell
+// export * from "./sidebar"; // Likely too app-specific
+// export * from "./chart"; // If based on a common library like Recharts and styled generically
+
+// Extended components
+// Assuming FormFieldWithLabel is in extended/ and is meant to be exported.
+// If it's not directly in ui/extended/ or ui/, the path needs adjustment.
+// For now, assuming it's intended for export if it exists and is generic.
+// export * from "./extended/FormFieldWithLabel"; // Path needs to be correct relative to this index.ts
+
+// Note: Some components like OnboardingModal, sidebar, chart might be too application-specific
+// or rely on heavier dependencies not suitable for a lightweight UI kit.
+// They would need careful evaluation before inclusion.
+// The duplicate help-modal.tsx vs HelpModal.tsx needs to be resolved; only one should be exported.
+// For this conceptual index, I've included HelpModal.tsx (assuming it's the correct one).
+// If FormFieldWithLabel.tsx is located at src/components/ui/extended/FormFieldWithLabel.tsx,
+// then the export path should be "./extended/FormFieldWithLabel".
+// Let's assume it is for now.
+export * from "./extended/FormFieldWithLabel";
+
+// It's good practice to ensure all exported paths are valid.
+// The file `help-modal.tsx` (lowercase) was also listed. If it's different from `HelpModal.tsx` (uppercase)
+// and also intended for export, it should be added. If it's a duplicate, it should be removed from the source.
+// I will assume `HelpModal.tsx` is the canonical one.

--- a/src/lib/agent-utils.ts
+++ b/src/lib/agent-utils.ts
@@ -1,63 +1,139 @@
-import { SavedAgentConfiguration } from '@/types/agent-configs-new';
+import { SavedAgentConfiguration, AgentConfig, LLMAgentConfig, WorkflowAgentConfig, AgentFramework } from '@/types/agent-types'; // Updated imports
 import * as yaml from 'js-yaml';
 
-interface AgentCardMetadata {
-  id: string;
-  name: string;
-  description?: string;
-  version: string;
-  a2aEnabled?: boolean;
-  a2aCommunicationChannels?: SavedAgentConfiguration['config']['a2a']['communicationChannels'];
-  // Add other relevant fields for interoperability as they are defined.
-  // For example, public keys, endpoint URLs, etc.
-  // Assuming 'config.security.publicKey' might be a field for a public key
-  publicKey?: string;
-  // Assuming 'config.connectors.http.endpoint' might be an endpoint
-  httpEndpoint?: string;
+// Define a more comprehensive structure for the manifest
+interface AgentManifest {
+  manifestVersion: string;
+  agentId: string;
+  agentName: string;
+  agentDescription?: string;
+  agentVersion: string;
+  createdAt?: string;
+  updatedAt?: string;
+  tags?: string[];
+  icon?: string;
+  isRootAgent?: boolean;
+  framework?: AgentFramework;
+  modelConfiguration?: {
+    modelName?: string;
+    temperature?: number;
+    [key: string]: any; // For other model params
+  };
+  systemPrompt?: string;
+  goal?: string;
+  tasks?: string[] | string; // agentTasks can be string or string[] depending on source
+  restrictions?: string[] | string; // agentRestrictions can be string or string[]
+  workflowConfiguration?: {
+    workflowType?: string; // e.g., sequential, parallel, loop from detailedWorkflowType
+    steps?: any[]; // Simplified structure from agentData.config.workflowSteps
+  };
+  toolsUsed?: Array<{
+    toolId: string;
+    name?: string;
+    description?: string;
+    genkitToolName?: string;
+    configuration?: any;
+  }>;
+  dependencies?: string[]; // Simulated for now
+  statePersistence?: AgentConfig['statePersistence'];
+  ragConfig?: AgentConfig['rag'];
+  artifactsConfig?: AgentConfig['artifacts'];
+  a2aConfig?: AgentConfig['a2a'];
+  evaluationGuardrails?: AgentConfig['evaluationGuardrails'];
+  deploymentConfig?: SavedAgentConfiguration['deploymentConfig'];
+  // Add any other fields that might be relevant from SavedAgentConfiguration
+  rawConfig?: AgentConfig; // Optionally include the raw config for completeness
 }
 
-const selectAgentMetadata = (agentData: SavedAgentConfiguration): AgentCardMetadata => {
-  const metadata: AgentCardMetadata = {
-    id: agentData.id,
-    name: agentData.name,
-    description: agentData.description,
-    version: agentData.version,
+const prepareAgentManifestData = (agentData: SavedAgentConfiguration): AgentManifest => {
+  const config = agentData.config; // Convenience alias
+
+  const manifest: AgentManifest = {
+    manifestVersion: "1.0.0",
+    agentId: agentData.id,
+    agentName: agentData.agentName,
+    agentDescription: agentData.agentDescription,
+    agentVersion: agentData.agentVersion,
+    createdAt: agentData.createdAt,
+    updatedAt: agentData.updatedAt,
+    tags: agentData.tags,
+    icon: agentData.icon,
+    isRootAgent: config?.isRootAgent, // Assuming isRootAgent is directly in config
+    framework: config?.framework,
+    systemPrompt: config?.systemPromptGenerated || (config as LLMAgentConfig)?.manualSystemPromptOverride, // Handle both prompt fields
+    dependencies: (agentData.tools || []).map(toolId => typeof toolId === 'string' ? toolId : toolId.id), // Simplified dependency list
+    statePersistence: config?.statePersistence,
+    ragConfig: config?.rag,
+    artifactsConfig: config?.artifacts,
+    a2aConfig: config?.a2a,
+    evaluationGuardrails: config?.evaluationGuardrails,
+    deploymentConfig: agentData.deploymentConfig,
+    // rawConfig: config, // Uncomment if raw config is desired
   };
 
-  if (agentData.config?.a2a?.enabled) {
-    metadata.a2aEnabled = true;
-    metadata.a2aCommunicationChannels = agentData.config.a2a.communicationChannels?.map(channel => ({
-      id: channel.id,
-      name: channel.name,
-      direction: channel.direction,
-      messageFormat: channel.messageFormat,
-      syncMode: channel.syncMode,
-      targetAgentId: channel.targetAgentId,
-      schema: channel.schema, // Include schema if present
+  // Model Configuration (primarily for LLM agents)
+  if (config?.type === 'llm') {
+    const llmConfig = config as LLMAgentConfig;
+    manifest.modelConfiguration = {
+      modelName: llmConfig.agentModel,
+      temperature: llmConfig.agentTemperature,
+      // Potentially add other model params if they exist in llmConfig.modelParams or similar
+      ...(llmConfig.modelParams && { customParams: llmConfig.modelParams }),
+    };
+    manifest.goal = llmConfig.agentGoal;
+    manifest.tasks = llmConfig.agentTasks; // This could be string or string[]
+    manifest.restrictions = llmConfig.agentRestrictions; // This could be string or string[]
+  }
+
+  // Workflow Configuration
+  if (config?.type === 'workflow') {
+    const workflowConfig = config as WorkflowAgentConfig;
+    manifest.workflowConfiguration = {
+      workflowType: workflowConfig.workflowType, // This might be 'sequential', 'parallel', etc.
+      // Map workflowSteps to a simpler structure if needed, or include as is
+      steps: workflowConfig.workflowSteps?.map(step => ({
+        name: step.name,
+        description: step.description,
+        agentId: step.agentId,
+        inputMapping: step.inputMapping, // Could be string or object
+        outputKey: step.outputKey,
+      })),
+    };
+    // Workflow agents can also have goal/tasks/etc. if they are also LLM-driven for some aspects
+    if (workflowConfig.agentGoal) manifest.goal = workflowConfig.agentGoal;
+    if (workflowConfig.agentTasks) manifest.tasks = workflowConfig.agentTasks;
+
+  }
+
+  // Tools Used
+  if (agentData.toolsDetails && agentData.toolsDetails.length > 0) {
+    manifest.toolsUsed = agentData.toolsDetails.map(toolDetail => ({
+      toolId: toolDetail.id,
+      name: toolDetail.name, // name from toolsDetails
+      description: toolDetail.description, // description from toolsDetails
+      genkitToolName: toolDetail.genkitToolName,
+      configuration: agentData.toolConfigsApplied?.[toolDetail.id],
     }));
+  } else if (agentData.tools && agentData.tools.length > 0) {
+    // Fallback if toolsDetails is not populated but tools array (of IDs) is
+    manifest.toolsUsed = agentData.tools.map(toolIdOrObject => {
+      const toolId = typeof toolIdOrObject === 'string' ? toolIdOrObject : toolIdOrObject.id;
+      return {
+        toolId: toolId,
+        configuration: agentData.toolConfigsApplied?.[toolId],
+      };
+    });
   }
 
-  // Example of how to include other potential metadata:
-  if (agentData.config?.security?.publicKey) {
-    metadata.publicKey = agentData.config.security.publicKey;
-  }
-
-  if (agentData.config?.connectors?.http?.endpoint) {
-    metadata.httpEndpoint = agentData.config.connectors.http.endpoint;
-  }
-
-  // Add more fields as they become standardized in SavedAgentConfiguration
-  // e.g., from agentData.config.capabilities, agentData.config.tools, etc.
-
-  return metadata;
+  return manifest;
 };
 
-export const generateAgentCardJson = (agentData: SavedAgentConfiguration): string => {
-  const metadata = selectAgentMetadata(agentData);
-  return JSON.stringify(metadata, null, 2);
+export const generateAgentManifestJson = (agentData: SavedAgentConfiguration): string => {
+  const manifestData = prepareAgentManifestData(agentData);
+  return JSON.stringify(manifestData, null, 2);
 };
 
-export const generateAgentCardYaml = (agentData: SavedAgentConfiguration): string => {
-  const metadata = selectAgentMetadata(agentData);
-  return yaml.dump(metadata);
+export const generateAgentManifestYaml = (agentData: SavedAgentConfiguration): string => {
+  const manifestData = prepareAgentManifestData(agentData);
+  return yaml.dump(manifestData);
 };


### PR DESCRIPTION
This commit introduces several new features and enhancements aimed at improving the extensibility and collaborative aspects of AgentVerse, as outlined in Bloco 20.

Key changes include:

1.  **Simulated Plugin System:**
    *   I've added UI in the Agent Builder's "Tools" tab so you can "install" new tools by pasting a JSON configuration. These tools are dynamically added to the available tools list for the current dialog session.

2.  **Simulated Agent Marketplace:**
    *   I've created a new `/marketplace` page listing mock agent templates.
    *   You can "install" these templates, which adds them to your local agent list (simulated using localStorage).
    *   I've also added a "Marketplace" link to the main sidebar.

3.  **Agent Manifest Generation:**
    *   I've enhanced the agent export functionality in the Agent Builder dialog.
    *   I've renamed "Export Config" to "Export Manifest (JSON)" and added an "Export Manifest (YAML)" option.
    *   These exports now generate a more comprehensive manifest file detailing the agent's configuration, including model details, tools, and other settings.

4.  **Simulated Agent Sharing:**
    *   I've added a "Share" button to agent cards, generating a Base64-encoded link containing the agent's configuration.
    *   The Agent Builder page can now detect and import agents from these shareable links after your confirmation, assigning a new unique ID to the imported agent.

5.  **Simulated Git Integration:**
    *   I've added "Save to Git (Simulado)" and "Revert from Git (Simulado)" buttons to the Agent Builder dialog when editing an agent.
    *   These buttons provide toast notifications to simulate Git operations. "Revert from Git" also resets the form to its initial state.

6.  **Conceptual UI Package Preparation:**
    *   I've reviewed UI components in `src/components/ui/` for potential packaging as a separate NPM library.
    *   I've added comments to `package.json`, `src/components/ui/index.ts`, and representative component files to document this conceptual preparation.

7.  **ADK Community Contributions Section:**
    *   I've created a new `/community` page.
    *   This page provides placeholder links to community resources, tutorials, and example agents.
    *   I've also added a "Comunidade" link to the main sidebar.