### PR TITLE
Optimize static assets and remove unused files

### DIFF
--- a/public/illustrations/empty-box.svg
+++ b/public/illustrations/empty-box.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
-  <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
-  <line x1="12" y1="22.08" x2="12" y2="12"></line>
-</svg>

--- a/public/illustrations/no-data.svg
+++ b/public/illustrations/no-data.svg
@@ -1,7 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-  <polyline points="14 2 14 8 20 8"></polyline>
-  <line x1="12" y1="18" x2="12" y2="12"></line>
-  <line x1="9" y1="15" x2="15" y2="15"></line>
-  <line x1="1" y1="1" x2="23" y2="23"></line>
-</svg>


### PR DESCRIPTION
This commit addresses several optimizations related to static assets:

- Verified that SVGs in `public/illustrations/` were already optimized.
- Confirmed that font loading in `src/app/fonts.ts` adheres to Next.js best practices for performance.
- Removed unused SVG files (`empty-box.svg` and `no-data.svg`) from `public/illustrations/` after confirming they were not referenced in the codebase.
- Verified that there are no broken static asset references.

These changes contribute to a cleaner codebase and ensure efficient loading of assets.